### PR TITLE
Update the dev server settings

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -111,16 +111,29 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
     const hotEntries = [];
     // If the target needs to run on development...
     if (target.runOnDevelopment) {
+      const devServerConfig = this._normalizeTargetDevServerSettings(target);
       // Add the dev server information to the configuration.
-      const { devServer } = target;
-      const devServerHost = devServer.host || 'localhost';
       config.devServer = {
-        port: devServer.port || 2509,
-        inline: !!devServer.reload,
+        port: devServerConfig.port,
+        inline: !!devServerConfig.reload,
         open: true,
+        openPage: '/',
       };
-      if (devServerHost !== 'localhost') {
-        config.devServer.public = devServerHost;
+      // If the configuration has a custom host, set it.
+      if (devServerConfig.host !== 'localhost') {
+        config.devServer.host = devServerConfig.host;
+      }
+      // If there are SSL files, set them on the server.
+      if (devServerConfig.ssl) {
+        config.devServer.https = {
+          key: devServerConfig.ssl.key,
+          cert: devServerConfig.ssl.cert,
+          ca: devServerConfig.ssl.ca,
+        };
+      }
+      // If the server is being proxied, add the public host.
+      if (devServerConfig.proxied) {
+        config.devServer.public = devServerConfig.proxied.host;
       }
       // If the target will run with the dev server and it requires HMR...
       if (target.hot) {
@@ -130,12 +143,9 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
         config.devServer.publicPath = '/';
         // Enable the dev server `hot` setting.
         config.devServer.hot = true;
-        // Build the host URL for the dev server as it will be needed for the hot entries.
-        const protocol = devServer.https ? 'https' : 'http';
-        const host = `${protocol}://${devServerHost}:${config.devServer.port}`;
         // Push the required entries to enable HMR on the dev server.
         hotEntries.push(...[
-          `webpack-dev-server/client?${host}`,
+          `webpack-dev-server/client?${devServerConfig.url}`,
           'webpack/hot/only-dev-server',
         ]);
       }
@@ -173,6 +183,56 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       config,
       params
     );
+  }
+  /**
+   * Check a target dev server settings in order to validate those that needs to be removed or
+   * completed with their default values.
+   * @param {Target} target The target information.
+   * @return {TargetDevServerSettings}
+   */
+  _normalizeTargetDevServerSettings(target) {
+    // Get a new copy of the config to work with.
+    const config = extend(true, {}, target.devServer);
+    /**
+     * Set a flag to know if at least one SSL file was sent.
+     * This flag is also used when reading the `proxied` settings to determine the default
+     * behaviour of `proxied.https`.
+     */
+    let hasASSLFile = false;
+    // Loop all the SSL files...
+    Object.keys(config.ssl).forEach((name) => {
+      const file = config.ssl[name];
+      // If there's an actual path...
+      if (typeof file === 'string') {
+        // ...set the flag to `true`.
+        hasASSLFile = true;
+        // Generate the path to the file.
+        config.ssl[name] = this.pathUtils.join(file);
+      }
+    });
+    // If no SSL file was sent, just remove the settings.
+    if (!hasASSLFile) {
+      delete config.ssl;
+    }
+    // If the server is being proxied...
+    if (config.proxied.enabled) {
+      // ...if no `host` was specified, use the one defined for the server.
+      if (config.proxied.host === null) {
+        config.proxied.host = config.host;
+      }
+      // If no `https` option was specified, set it to `true` if at least one SSL file was sent.
+      if (config.proxied.https === null) {
+        config.proxied.https = hasASSLFile;
+      }
+    } else {
+      // ...otherwise, just remove the setting.
+      delete config.proxied;
+    }
+
+    const protocol = config.ssl ? 'https' : 'http';
+    config.url = `${protocol}://${config.host}:${config.port}`;
+
+    return config;
   }
   /**
    * Creates a _'fake Webpack plugin'_ that detects when the bundle is being compiled in order to

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -166,6 +166,43 @@
  */
 
 /**
+ * @typedef {Object} TargetDevServerSSLSettings
+ * @property {string} key
+ * The path to the SSL key (`.key`).
+ * @property {string} cert
+ * The path to the SSL certificate (`.crt`).
+ * @property {string} ca
+ * The path to the SSL public file (`.pem`).
+ */
+
+/**
+ * @typedef {Object} TargetDevServerProxiedSettings
+ * @property {boolean} enabled
+ * Whether or not the dev server is being proxied.
+ * @property {string} host
+ * The host used to proxy the dev server.
+ * @property {boolean} https
+ * Whether or not the proxied host uses `https`.
+ */
+
+/**
+ * @typedef {Object} TargetDevServerSettings
+ * @property {number} port
+ * The server port.
+ * @property {string} host
+ * The dev server hostname.
+ * @property {string} url
+ * The complete URL for the dev server.
+ * @property {boolean} reload
+ * Whether or not to reload the server when the code changes.
+ * @property {?TargetDevServerSSLSettings} ssl
+ * The paths to the files to enable SSL on the dev server.
+ * @property {?TargetDevServerProxiedSettings} [proxied]
+ * When the dev server is being proxied (using `nginx` for example), there are certain
+ * functionalities, like hot module replacement and live reload, that need to be aware of this.
+ */
+
+/**
  * @typedef {function} ProviderRegisterMethod
  * @param {Jimple} app
  * A reference to the dependency injection container.


### PR DESCRIPTION
### What does this PR do?

Based on the upcoming changes from homer0/projext#10, this PRs updates the way the webpack dev server implementation in order to...

- Add support when the server is being proxied from another host.
- Add support for SSL certificates in order to enable HTTPS.
- Change the hostname.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
