### PR TITLE
Use the default HTML for browser targets

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const extend = require('extend');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
@@ -26,6 +25,10 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
    * @param {PathUtils}                    pathUtils                Required by `ConfigurationFile`
    *                                                                in order to build the path to
    *                                                                the overwrite file.
+   * @param {TargetsHTML#getFilepath}      targetsHTML              The service in charge of
+   *                                                                generating a default HTML file
+   *                                                                in case the target doesn't have
+   *                                                                one.
    * @param {WebpackBaseConfiguration}     webpackBaseConfiguration The configuration this one will
    *                                                                extend.
    */
@@ -33,6 +36,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
     appLogger,
     events,
     pathUtils,
+    targetsHTML,
     webpackBaseConfiguration
   ) {
     super(
@@ -51,6 +55,11 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
      * @type {Events}
      */
     this.events = events;
+    /**
+     * A local reference for the `targetsHTML` service.
+     * @type {TargetsHTML#getFilepath}
+     */
+    this.targetsHTML = targetsHTML;
   }
   /**
    * Create the configuration with the `entry`, the `output` and the plugins specifics for a
@@ -91,7 +100,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       new ExtractTextPlugin(output.css),
       // To automatically inject the `script` tag on the target `html` file.
       new HtmlWebpackPlugin(Object.assign({}, target.html, {
-        template: path.join(target.paths.source, target.html.template),
+        template: this.targetsHTML(target),
         inject: 'body',
       })),
       // To add the `async` attribute to the  `script` tag.
@@ -278,6 +287,7 @@ const webpackBrowserDevelopmentConfiguration = provider((app) => {
       app.get('appLogger'),
       app.get('events'),
       app.get('pathUtils'),
+      app.get('targetsHTML'),
       app.get('webpackBaseConfiguration')
     )
   );

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -18,19 +18,17 @@ const ConfigurationFile = require('../../abstracts/configurationFile');
 class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
   /**
    * Class constructor.
-   * @param {Logger}                       appLogger                To inform the user when the
-   *                                                                build is running on the dev
-   *                                                                server.
-   * @param {Events}                       events                   To reduce the configuration.
-   * @param {PathUtils}                    pathUtils                Required by `ConfigurationFile`
-   *                                                                in order to build the path to
-   *                                                                the overwrite file.
-   * @param {TargetsHTML#getFilepath}      targetsHTML              The service in charge of
-   *                                                                generating a default HTML file
-   *                                                                in case the target doesn't have
-   *                                                                one.
-   * @param {WebpackBaseConfiguration}     webpackBaseConfiguration The configuration this one will
-   *                                                                extend.
+   * @param {Logger}                   appLogger                To inform the user when the build
+   *                                                            is running on the dev server.
+   * @param {Events}                   events                   To reduce the configuration.
+   * @param {PathUtils}                pathUtils                Required by `ConfigurationFile`
+   *                                                            in order to build the path to the
+   *                                                            overwrite file.
+   * @param {TargetsHTML}              targetsHTML              The service in charge of generating
+   *                                                            a default HTML file in case the
+   *                                                            target doesn't have one.
+   * @param {WebpackBaseConfiguration} webpackBaseConfiguration The configuration this one will
+   *                                                            extend.
    */
   constructor(
     appLogger,
@@ -57,7 +55,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
     this.events = events;
     /**
      * A local reference for the `targetsHTML` service.
-     * @type {TargetsHTML#getFilepath}
+     * @type {TargetsHTML}
      */
     this.targetsHTML = targetsHTML;
   }
@@ -100,7 +98,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       new ExtractTextPlugin(output.css),
       // To automatically inject the `script` tag on the target `html` file.
       new HtmlWebpackPlugin(Object.assign({}, target.html, {
-        template: this.targetsHTML(target),
+        template: this.targetsHTML.getFilepath(target),
         inject: 'body',
       })),
       // To add the `async` attribute to the  `script` tag.

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
@@ -19,12 +18,17 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
    * @param {PathUtils}                    pathUtils                Required by `ConfigurationFile`
    *                                                                in order to build the path to
    *                                                                the overwrite file.
+   * @param {TargetsHTML#getFilepath}      targetsHTML              The service in charge of
+   *                                                                generating a default HTML file
+   *                                                                in case the target doesn't have
+   *                                                                one.
    * @param {WebpackBaseConfiguration}     webpackBaseConfiguration The configuration this one will
    *                                                                extend.
    */
   constructor(
     events,
     pathUtils,
+    targetsHTML,
     webpackBaseConfiguration
   ) {
     super(
@@ -38,6 +42,11 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
      * @type {Events}
      */
     this.events = events;
+    /**
+     * A local reference for the `targetsHTML` service.
+     * @type {TargetsHTML#getFilepath}
+     */
+    this.targetsHTML = targetsHTML;
   }
   /**
    * Create the configuration with the `entry`, the `output` and the plugins specifics for a
@@ -81,7 +90,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
           [
             // To automatically inject the `script` tag on the target `html` file.
             new HtmlWebpackPlugin(Object.assign({}, target.html, {
-              template: path.join(target.paths.source, target.html.template),
+              template: this.targetsHTML(target),
               inject: 'body',
             })),
             // To add the `async` attribute to the  `script` tag.
@@ -125,6 +134,7 @@ const webpackBrowserProductionConfiguration = provider((app) => {
     () => new WebpackBrowserProductionConfiguration(
       app.get('events'),
       app.get('pathUtils'),
+      app.get('targetsHTML'),
       app.get('webpackBaseConfiguration')
     )
   );

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -14,16 +14,15 @@ const ConfigurationFile = require('../../abstracts/configurationFile');
 class WebpackBrowserProductionConfiguration extends ConfigurationFile {
   /**
    * Class constructor.
-   * @param {Events}                       events                   To reduce the configuration.
-   * @param {PathUtils}                    pathUtils                Required by `ConfigurationFile`
-   *                                                                in order to build the path to
-   *                                                                the overwrite file.
-   * @param {TargetsHTML#getFilepath}      targetsHTML              The service in charge of
-   *                                                                generating a default HTML file
-   *                                                                in case the target doesn't have
-   *                                                                one.
-   * @param {WebpackBaseConfiguration}     webpackBaseConfiguration The configuration this one will
-   *                                                                extend.
+   * @param {Events}                   events                  To reduce the configuration.
+   * @param {PathUtils}                pathUtils                Required by `ConfigurationFile`
+   *                                                            in order to build the path to the
+   *                                                            overwrite file.
+   * @param {TargetsHTML}              targetsHTML              The service in charge of generating
+   *                                                            a default HTML file in case the
+   *                                                            target doesn't have one.
+   * @param {WebpackBaseConfiguration} webpackBaseConfiguration The configuration this one will
+   *                                                            extend.
    */
   constructor(
     events,
@@ -44,7 +43,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
     this.events = events;
     /**
      * A local reference for the `targetsHTML` service.
-     * @type {TargetsHTML#getFilepath}
+     * @type {TargetsHTML}
      */
     this.targetsHTML = targetsHTML;
   }
@@ -90,7 +89,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
           [
             // To automatically inject the `script` tag on the target `html` file.
             new HtmlWebpackPlugin(Object.assign({}, target.html, {
-              template: this.targetsHTML(target),
+              template: this.targetsHTML.getFilepath(target),
               inject: 'body',
             })),
             // To add the `async` attribute to the  `script` tag.

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -60,7 +60,12 @@
 
 /**
  * @external {Targets}
- * https://homer0.github.io/projext/class/src/services/building/targets.js~Targets.html
+ * https://homer0.github.io/projext/class/src/services/targets/targets.js~Targets.html
+ */
+
+/**
+ * @external {TargetsHTML}
+ * https://homer0.github.io/projext/class/src/services/targets/targetsHTML.js~TargetsHTML.html
  */
 
 /**

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -38,6 +38,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const appLogger = 'appLogger';
     const events = 'events';
     const pathUtils = 'pathUtils';
+    const targetsHTML = 'targetsHTML';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     let sut = null;
     // When
@@ -45,6 +46,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     // Then
@@ -58,6 +60,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     );
     expect(sut.appLogger).toBe(appLogger);
     expect(sut.events).toBe(events);
+    expect(sut.targetsHTML).toBe(targetsHTML);
   });
 
   it('should create a configuration', () => {
@@ -67,6 +70,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -111,6 +115,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -122,7 +127,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -142,6 +147,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration with HMR and source map', () => {
@@ -151,6 +158,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -204,6 +212,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -215,7 +224,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -235,6 +244,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration for building and running the dev server', () => {
@@ -250,6 +261,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -324,6 +336,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -335,7 +348,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -355,6 +368,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
+
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
     expect(compiler.plugin).toHaveBeenCalledTimes(['compile', 'done'].length);
@@ -387,6 +403,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -460,6 +477,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -471,7 +489,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -491,6 +509,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
+
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
     expect(compiler.plugin).toHaveBeenCalledTimes(['compile', 'done'].length);
@@ -523,6 +544,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -602,6 +624,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -613,7 +636,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -635,6 +658,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
+
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
     expect(compiler.plugin).toHaveBeenCalledTimes(['compile', 'done'].length);
@@ -667,6 +693,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -746,6 +773,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -757,7 +785,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -777,6 +805,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
+
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
     expect(compiler.plugin).toHaveBeenCalledTimes(['compile', 'done'].length);
@@ -809,6 +840,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -888,6 +920,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       appLogger,
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -899,7 +932,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -919,6 +952,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
+
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
     expect(compiler.plugin).toHaveBeenCalledTimes(['compile', 'done'].length);
@@ -955,5 +991,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(sut).toBeInstanceOf(WebpackBrowserDevelopmentConfiguration);
     expect(sut.appLogger).toBe('appLogger');
     expect(sut.events).toBe('events');
+    expect(sut.targetsHTML).toBe('targetsHTML');
   });
 });

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -70,7 +70,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -147,8 +149,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration with HMR and source map', () => {
@@ -158,7 +160,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -244,8 +248,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration for building and running the dev server', () => {
@@ -261,7 +265,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -368,8 +374,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
 
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
@@ -403,7 +409,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -509,8 +517,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
 
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
@@ -544,7 +552,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -658,8 +668,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
 
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
@@ -693,7 +703,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -805,8 +817,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
 
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);
@@ -840,7 +852,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const pathUtils = {
       join: jest.fn((rest) => rest),
     };
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -952,8 +966,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
 
     devSeverPlugin = result.plugins.slice().pop();
     devSeverPlugin.apply(compiler);

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -43,12 +43,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
     // Given
     const events = 'events';
     const pathUtils = 'pathUtils';
+    const targetsHTML = 'targetsHTML';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     let sut = null;
     // When
     sut = new WebpackBrowserProductionConfiguration(
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     // Then
@@ -61,6 +63,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       webpackBaseConfiguration
     );
     expect(sut.events).toBe(events);
+    expect(sut.targetsHTML).toBe(targetsHTML);
   });
 
   it('should create a configuration', () => {
@@ -69,6 +72,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -112,6 +116,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     sut = new WebpackBrowserProductionConfiguration(
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -123,7 +128,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -145,6 +150,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration with source map', () => {
@@ -153,6 +160,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -199,6 +207,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     sut = new WebpackBrowserProductionConfiguration(
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);
@@ -210,7 +219,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
       target.html,
       {
-        template: `${target.paths.source}/${target.html.template}`,
+        template: target.html.template,
         inject: 'body',
       }
     ));
@@ -232,6 +241,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       expectedConfig,
       params
     );
+    expect(targetsHTML).toHaveBeenCalledTimes(1);
+    expect(targetsHTML).toHaveBeenCalledWith(target);
   });
 
   it('shouldn\'t add the HTML and Compression plugins for a library target', () => {
@@ -240,6 +251,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
+    const targetsHTML = 'targetsHTML';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -284,6 +296,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     sut = new WebpackBrowserProductionConfiguration(
       events,
       pathUtils,
+      targetsHTML,
       webpackBaseConfiguration
     );
     result = sut.getConfig(params);

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -72,7 +72,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -150,8 +152,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
   });
 
   it('should create a configuration with source map', () => {
@@ -160,7 +162,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
       reduce: jest.fn((eventName, loaders) => loaders),
     };
     const pathUtils = 'pathUtils';
-    const targetsHTML = jest.fn((targetInfo) => targetInfo.html.template);
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const target = {
       name: 'targetName',
@@ -241,8 +245,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       expectedConfig,
       params
     );
-    expect(targetsHTML).toHaveBeenCalledTimes(1);
-    expect(targetsHTML).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
   });
 
   it('shouldn\'t add the HTML and Compression plugins for a library target', () => {


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#12 projext added support for a _"default HTML"_ so browser targets won't need an HTML file in order to be bundled.

This PR implements the new service `targetsHTML` that checks whether the target has an HTML file and if it doesn't it fallbacks to the _"default HTML"_.

### How should it be tested manually?

1. Try to build and run a target without an HTML file.
2. Run the tests.

### Are there any related PRs?

- homer0/projext#12
