### PR TITLE
Compress a library target if specified on the settings

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -75,16 +75,26 @@ class WebpackConfiguration {
     return definitions;
   }
   /**
-   * In case the target is a library, this method will be called to generate the library options
-   * for Webpack.
+   * In case the target is a library, this method will be called in order to get the extra output
+   * settings webpack needs.
    * @param {Target} target The target information.
    * @return {Object}
    */
   getLibraryOptions(target) {
     const { libraryOptions } = target;
-    return Object.assign({
+    // Create the object for webpack.
+    const newOptions = Object.assign({
       libraryTarget: 'commonjs2',
     }, libraryOptions);
+
+    // Remove any option unsupported by the webpack schema
+    [
+      'compress',
+    ].forEach((invalidOption) => {
+      delete newOptions[invalidOption];
+    });
+
+    return newOptions;
   }
   /**
    * This method generates a complete Webpack configuration for a target.

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -125,6 +125,20 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
         inline: !!devServerConfig.reload,
         open: true,
       };
+      /**
+       * This setting is specific to the webpack dev server and it allows web apps that use
+       * the history API to fallback to the server's root in case the app is loaded on a sub
+       * route, that way the custom routing can redirect the user.
+       * This is not yet documented on the projext configuration because I'm not entirely sure
+       * other dev servers can support it that easily, so for the moment if will be like a
+       * _"hidden option"_ for this plugin; While implementing the next build engine I'll go
+       * back and either document it as special setting for this plugin or adding to the
+       * projext main configuration.
+       * @todo Validate historyApiFallback
+       */
+      if (devServerConfig.historyApiFallback) {
+        config.devServer.historyApiFallback = devServerConfig.historyApiFallback;
+      }
       // If the configuration has a custom host, set it.
       if (devServerConfig.host !== 'localhost') {
         config.devServer.host = devServerConfig.host;

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -107,7 +107,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       // To optimize the SCSS and remove repeated declarations.
       new OptimizeCssAssetsPlugin(),
       // To compress the emitted assets using gzip, if the target is not a library.
-      ...(target.library ? [] : [new CompressionPlugin()]),
+      ...(!target.library || target.libraryOptions.compress ? [new CompressionPlugin()] : []),
     ];
     // Reduce the configuration
     return this.events.reduce(

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -260,6 +260,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     const target = {
       name: 'targetName',
       library: true,
+      libraryOptions: {},
       folders: {
         build: 'build-folder',
       },
@@ -318,6 +319,86 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CompressionPlugin).toHaveBeenCalledTimes(0);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      'webpack-browser-production-configuration',
+      expectedConfig,
+      params
+    );
+  });
+
+  it('should add the Compression plugins for a library target when enabled by setting', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const targetsHTML = 'targetsHTML';
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      library: true,
+      libraryOptions: {
+        compress: true,
+      },
+      folders: {
+        build: 'build-folder',
+      },
+      paths: {
+        source: 'source-path',
+      },
+      html: {
+        template: 'index.html',
+      },
+      sourceMap: {},
+    };
+    const definitions = 'definitions';
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      css: 'statics/css/build.css',
+    };
+    const params = {
+      target,
+      definitions,
+      entry,
+      output,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        publicPath: '/',
+      },
+      plugins: expect.any(Array),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackBrowserProductionConfiguration(
+      events,
+      pathUtils,
+      targetsHTML,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(ExtractTextPlugin).toHaveBeenCalledTimes(1);
+    expect(ExtractTextPlugin).toHaveBeenCalledWith(output.css);
+    expect(HtmlWebpackPlugin).toHaveBeenCalledTimes(0);
+    expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledTimes(0);
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
+    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
+    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+      sourceMap: false,
+    });
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       'webpack-browser-production-configuration',


### PR DESCRIPTION
### What does this PR do?

- Adds support for the new `libraryOptions.compress` setting for browser target libraries.
- Implements the `devServer.historyAPIFallback` setting. 

### How should it be tested manually?

```bash
yarn test
# or
npm test
```