### PR TITLE
Implement the new CSS settings, includeModules and update jimpex

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "jest-ex": "4.0.0",
       "jest-cli": "22.1.4",
       "jasmine-expect": "3.8.3",
-      "jimpex": "^2.0.0",
+      "jimpex": "^2.1.0",
       "esdoc": "1.0.4",
       "esdoc-standard-plugin": "1.0.0",
       "esdoc-node": "1.0.3",

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -268,7 +268,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
       {
         // `.svg` files inside a `fonts` folder.
         test: /\.svg(\?(v=\d+\.\d+\.\d+|\w+))?$/,
-        include: new RegExp(`${target.paths.source}\\/(?:.*?/)?fonts/.*?`, 'i'),
+        include: new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
         use: [{
           loader: 'file-loader',
           options: {
@@ -356,7 +356,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
          */
         /favicon\.\w+$/,
         // Exclude svg files that were identified as fonts.
-        new RegExp(`${target.paths.source}\\/(?:.*?/)?fonts/.*?`, 'i'),
+        new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
       ],
       use: [
         {

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -354,7 +354,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
          * The reason is that favicons need to be on the root directory for the browser to
          * automatically detect them, and they only include optimization options for `png`.
          */
-        /favicon\.\w+$/,
+        /favicon\.\w+$/i,
         // Exclude svg files that were identified as fonts.
         new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
       ],
@@ -415,7 +415,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
     const rules = [{
       test: /\.(png|ico)$/i,
       // Only apply to files that match the `favicon` name/path.
-      include: /favicon/,
+      include: /favicon\.\w+$/i,
       use: [
         {
           loader: 'file-loader',

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -117,7 +117,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
       importRules: 2,
     };
     // If the target uses CSS modules...
-    if (params.target.CSSModules) {
+    if (params.target.css.modules) {
       // ...enable them on the CSS loader configuration.
       cssLoaderConfig.modules = true;
       // Add the modules name format.
@@ -146,14 +146,17 @@ class WebpackRulesConfiguration extends ConfigurationFile {
     ];
     if (params.target.is.browser) {
       eventName = 'webpack-scss-rules-configuration-for-browser';
-      /**
-       * Wrap the loaders settings on the the plugin that extracts all the stylesheets on a
-       * single file.
-       */
-      use = ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use,
-      });
+      // If the target needs to inject the styles on the `<head>`...
+      if (params.target.css.inject) {
+        // ...add the style loader.
+        use.unshift('style-loader');
+      } else {
+        // ...otherwise, wrap the loaders on the plugin that creates a single stylesheet.
+        use = ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use,
+        });
+      }
     }
 
     const rules = [{
@@ -188,14 +191,17 @@ class WebpackRulesConfiguration extends ConfigurationFile {
 
     if (params.target.is.browser) {
       eventName = 'webpack-css-rules-configuration-for-browser';
-      /**
-       * Wrap the loaders settings on the the plugin that extracts all the stylesheets on a
-       * single file.
-       */
-      use = ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use,
-      });
+      // If the target needs to inject the styles on the `<head>`...
+      if (params.target.css.inject) {
+        // ...add the style loader.
+        use.unshift('style-loader');
+      } else {
+        // ...otherwise, wrap the loaders on the plugin that creates a single stylesheet.
+        use = ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use,
+        });
+      }
     }
 
     const rules = [{

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -79,8 +79,8 @@ class WebpackRulesConfiguration extends ConfigurationFile {
       test: /\.jsx?$/i,
       // Only check for files on the target source directory and the configurations folder.
       include: [
-        RegExp(target.folders.source),
-        RegExp(this.pathUtils.join('config')),
+        new RegExp(target.folders.source),
+        new RegExp(this.pathUtils.join('config')),
       ],
       use: [{
         loader: 'babel-loader',
@@ -256,12 +256,12 @@ class WebpackRulesConfiguration extends ConfigurationFile {
    *       for handling fonts than the `file-loader`.
    */
   getFontsRules(params) {
-    const { output: { fonts: name } } = params;
+    const { target, output: { fonts: name } } = params;
     const rules = [
       {
         // `.svg` files inside a `fonts` folder.
         test: /\.svg(\?(v=\d+\.\d+\.\d+|\w+))?$/,
-        include: /fonts/,
+        include: new RegExp(`${target.paths.source}\\/(?:.*?/)?fonts/.*?`, 'i'),
         use: [{
           loader: 'file-loader',
           options: {
@@ -338,15 +338,19 @@ class WebpackRulesConfiguration extends ConfigurationFile {
    * @return {Array}
    */
   getImagesRules(params) {
-    const { output: { images: name } } = params;
+    const { target, output: { images: name } } = params;
     const rules = [{
       test: /\.(jpe?g|png|gif|svg|ico)$/i,
-      /**
-       * This excludes names that match `favicon` because there are specific rules for favicons.
-       * The reason is that favicons need to be on the root directory for the browser to
-       * automatically detect them, and they only include optimization options for `png`.
-       */
-      exclude: /favicon/,
+      exclude: [
+        /**
+         * This excludes names that match `favicon` because there are specific rules for favicons.
+         * The reason is that favicons need to be on the root directory for the browser to
+         * automatically detect them, and they only include optimization options for `png`.
+         */
+        /favicon\.\w+$/,
+        // Exclude svg files that were identified as fonts.
+        new RegExp(`${target.paths.source}\\/(?:.*?/)?fonts/.*?`, 'i'),
+      ],
       use: [
         {
           loader: 'file-loader',

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -81,6 +81,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
       include: [
         new RegExp(target.folders.source),
         new RegExp(this.pathUtils.join('config')),
+        ...target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
       ],
       use: [{
         loader: 'babel-loader',

--- a/tests/services/configurations/rulesConfiguration.test.js
+++ b/tests/services/configurations/rulesConfiguration.test.js
@@ -174,7 +174,10 @@ describe('services/configurations:rulesConfiguration', () => {
     rules.imagesRules = [
       {
         test: expect.any(RegExp),
-        exclude: expect.any(RegExp),
+        exclude: expect.arrayContaining([
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ]),
         use: [
           {
             loader: 'file-loader',
@@ -265,6 +268,9 @@ describe('services/configurations:rulesConfiguration', () => {
       name: targetName,
       folders: {
         source: 'src/target',
+      },
+      paths: {
+        source: '/absolute/src/target',
       },
       is: {
         node: true,
@@ -436,6 +442,9 @@ describe('services/configurations:rulesConfiguration', () => {
       name: targetName,
       folders: {
         source: 'src/target',
+      },
+      paths: {
+        source: '/absolute/src/target',
       },
       is: {
         node: true,
@@ -609,6 +618,9 @@ describe('services/configurations:rulesConfiguration', () => {
       name: targetName,
       folders: {
         source: 'src/target',
+      },
+      paths: {
+        source: '/absolute/src/target',
       },
       is: {
         node: false,
@@ -796,6 +808,9 @@ describe('services/configurations:rulesConfiguration', () => {
       name: targetName,
       folders: {
         source: 'src/target',
+      },
+      paths: {
+        source: '/absolute/src/target',
       },
       is: {
         node: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4913,9 +4913,9 @@ jest-worker@^22.1.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jimpex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-2.0.0.tgz#f746cabcda3c41e5e8312895b759e4e58ad57e4d"
+jimpex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-2.1.0.tgz#cb7099ceaa077b7cb8b57d36960558c702536730"
   dependencies:
     body-parser "1.18.2"
     compression "1.7.1"
@@ -4930,7 +4930,7 @@ jimpex@^2.0.0:
     urijs "1.19.0"
     wootils "^1.0.5"
 
-jimple@homer0/jimple:
+"jimple@github:homer0/jimple", jimple@homer0/jimple:
   version "1.4.6"
   resolved "https://codeload.github.com/homer0/jimple/tar.gz/1f123c2ba1f0aef14de159747455f877f70e0c9d"
 


### PR DESCRIPTION
### What does this PR do?

#### Fixes the regular expressions for including and excluding `svg` files.

The fonts loader was recognizing every `svg` file that matched with `/fonts/` as a font. The intention was to only pick `svg` files inside a `fonts` directory, but if the path of the project included the word `fonts` anywhere, it would match the expression and the file would be handled as a font.

Now the expression was changed to this:

```js
new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i')
```

Which means: Inside the target source directory, and on **directory** called `fonts`.

I also included the same expression as `exclude` on the images loader, because even if the `svg` was being handled as a font, the image loader was also copying it as an image.

#### Implement the new settings.

The full description of the settings is on homer0/projext#15, so I recommend you to read the PR to fully understand how they work.

The changes on the settings include the replacement of browser targets `CSSModules` flag for `css.modules`, so that's why this PR is breaking.

#### Update [jimpex](https://yarnpkg.com/en/package/jimpex) to `2.1.0`

Because I released a couple of days ago :P.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
