### PR TITLE
Implement excludeModules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ const {
 const {
   webpackMiddlewares,
 } = require('./services/server');
+
+const { name: pluginName } = require('../package.json');
 /**
  * This is the method called by projext when loading the plugin and it takes care of registering
  * the Webpack build engine service and all the other services the engine depends on.
@@ -22,9 +24,20 @@ const {
  * @ignore
  */
 const loadPlugin = (app) => {
+  /**
+   * These will be used when defining the external dependencies of a Node target. Since their names
+   * don't match a dependency of the `package.json`, if not defined, webpack would try to bundle
+   * the plugin and all its dependencies.
+   */
+  app.set('webpackDefaultExternals', () => [
+    `${pluginName}/express`,
+    `${pluginName}/jimpex`,
+  ]);
+  // Register the main services of the build engine.
   app.register(webpackConfiguration);
   app.register(webpackBuildEngine);
 
+  // Register the services for building the targets confirmations.
   app.register(webpackBaseConfiguration);
   app.register(webpackBrowserDevelopmentConfiguration);
   app.register(webpackBrowserProductionConfiguration);

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -18,11 +18,16 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
    *                                                                the overwrite file.
    * @param {WebpackBaseConfiguration}     webpackBaseConfiguration The configuration this one will
    *                                                                extend.
+   * @param {Array}                        webpackDefaultExternals  The list of modules this plugin
+   *                                                                makes available and that need to
+   *                                                                be defined as externals in case
+   *                                                                the user uses them.
    */
   constructor(
     events,
     pathUtils,
-    webpackBaseConfiguration
+    webpackBaseConfiguration,
+    webpackDefaultExternals
   ) {
     super(
       pathUtils,
@@ -35,6 +40,13 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
      * @type {Events}
      */
     this.events = events;
+    /**
+     * A list of modules this plugin makes available and that need to be defined as externals on
+     * the webpack configuration in case the user uses them. If not defined as externals, webpack
+     * would try to bundle the entire plugin and its dependencies.
+     * @type {Array}
+     */
+    this.webpackDefaultExternals = webpackDefaultExternals;
   }
   /**
    * Create the configuration with the `entry`, the `output` and the plugins specifics for a
@@ -65,6 +77,11 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       // Push the plugin that executes the target.
       plugins.push(new webpackNodeUtils.WebpackNodeUtilsRunner());
     }
+    // Define the list of modules that should be used as externals
+    const externals = [
+      ...this.webpackDefaultExternals,
+      ...target.excludeModules,
+    ];
     // Define the rest of the configuration.
     const config = {
       entry,
@@ -84,7 +101,7 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
        * Mark all the project dependencies, including the devDependencies, as externals. This way,
        * Webpack won't try to push them into the bundle.
        */
-      externals: webpackNodeUtils.externals({}, true),
+      externals: webpackNodeUtils.externals({}, true, externals),
     };
     // Reduce the configuration.
     return this.events.reduce(
@@ -110,7 +127,8 @@ const webpackNodeDevelopmentConfiguration = provider((app) => {
     () => new WebpackNodeDevelopmentConfiguration(
       app.get('events'),
       app.get('pathUtils'),
-      app.get('webpackBaseConfiguration')
+      app.get('webpackBaseConfiguration'),
+      app.get('webpackDefaultExternals')
     )
   );
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,9 @@
 const JimpleMock = require('/tests/mocks/jimple.mock');
 
+const pluginName = 'projext-plugin-webpack';
+
 jest.mock('jimple', () => JimpleMock);
+jest.mock('../package.json', () => ({ name: pluginName }));
 jest.unmock('/src/index');
 
 require('jasmine-expect');
@@ -12,10 +15,21 @@ describe('plugin:projextWebpack', () => {
     // Given
     const app = {
       register: jest.fn(),
+      set: jest.fn(),
     };
+    let externalsFunction = null;
+    let result = null;
     // When
     plugin(app);
+    [[, externalsFunction]] = app.set.mock.calls;
+    result = externalsFunction();
     // Then
+    expect(result).toEqual([
+      `${pluginName}/express`,
+      `${pluginName}/jimpex`,
+    ]);
+    expect(app.set).toHaveBeenCalledTimes(1);
+    expect(app.set).toHaveBeenCalledWith('webpackDefaultExternals', expect.any(Function));
     expect(app.register).toHaveBeenCalledTimes([
       'webpackConfiguration',
       'webpackBuildEngine',

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -31,12 +31,14 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     const events = 'events';
     const pathUtils = 'pathUtils';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackDefaultExternals = 'webpackDefaultExternals';
     let sut = null;
     // When
     sut = new WebpackNodeDevelopmentConfiguration(
       events,
       pathUtils,
-      webpackBaseConfiguration
+      webpackBaseConfiguration,
+      webpackDefaultExternals
     );
     // Then
     expect(sut).toBeInstanceOf(WebpackNodeDevelopmentConfiguration);
@@ -48,6 +50,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       webpackBaseConfiguration
     );
     expect(sut.events).toBe(events);
+    expect(sut.webpackDefaultExternals).toBe(webpackDefaultExternals);
   });
 
   it('should create a configuration', () => {
@@ -57,6 +60,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     };
     const pathUtils = 'pathUtils';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackDefaultExternals = [];
     const target = {
       name: 'targetName',
       folders: {
@@ -65,6 +69,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       paths: {
         source: 'source-path',
       },
+      excludeModules: [],
     };
     const entry = {
       [target.name]: ['index.js'],
@@ -98,13 +103,23 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     sut = new WebpackNodeDevelopmentConfiguration(
       events,
       pathUtils,
-      webpackBaseConfiguration
+      webpackBaseConfiguration,
+      webpackDefaultExternals
     );
     result = sut.getConfig(params);
     // Then
     expect(result).toEqual(expectedConfig);
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(webpackNodeUtilsMock.externals).toHaveBeenCalledTimes(1);
+    expect(webpackNodeUtilsMock.externals).toHaveBeenCalledWith(
+      {},
+      true,
+      [
+        ...webpackDefaultExternals,
+        ...target.excludeModules,
+      ]
+    );
     expect(webpackNodeUtilsMock.WebpackNodeUtilsRunnerMockMock)
     .toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
@@ -122,6 +137,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     };
     const pathUtils = 'pathUtils';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackDefaultExternals = [];
     const target = {
       name: 'targetName',
       folders: {
@@ -130,6 +146,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       paths: {
         source: 'source-path',
       },
+      excludeModules: [],
       runOnDevelopment: true,
     };
     const entry = {
@@ -164,7 +181,8 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     sut = new WebpackNodeDevelopmentConfiguration(
       events,
       pathUtils,
-      webpackBaseConfiguration
+      webpackBaseConfiguration,
+      webpackDefaultExternals
     );
     result = sut.getConfig(params);
     // Then
@@ -174,7 +192,14 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(webpackNodeUtilsMock.WebpackNodeUtilsRunnerMockMock)
     .toHaveBeenCalledTimes(1);
     expect(webpackNodeUtilsMock.externals).toHaveBeenCalledTimes(1);
-    expect(webpackNodeUtilsMock.externals).toHaveBeenCalledWith({}, true);
+    expect(webpackNodeUtilsMock.externals).toHaveBeenCalledWith(
+      {},
+      true,
+      [
+        ...webpackDefaultExternals,
+        ...target.excludeModules,
+      ]
+    );
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       'webpack-node-development-configuration',
@@ -201,5 +226,6 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(serviceFn).toBeFunction();
     expect(sut).toBeInstanceOf(WebpackNodeDevelopmentConfiguration);
     expect(sut.events).toBe('events');
+    expect(sut.webpackDefaultExternals).toBe('webpackDefaultExternals');
   });
 });

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -31,12 +31,14 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     const events = 'events';
     const pathUtils = 'pathUtils';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackDefaultExternals = 'webpackDefaultExternals';
     let sut = null;
     // When
     sut = new WebpackNodeProductionConfiguration(
       events,
       pathUtils,
-      webpackBaseConfiguration
+      webpackBaseConfiguration,
+      webpackDefaultExternals
     );
     // Then
     expect(sut).toBeInstanceOf(WebpackNodeProductionConfiguration);
@@ -48,6 +50,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       webpackBaseConfiguration
     );
     expect(sut.events).toBe(events);
+    expect(sut.webpackDefaultExternals).toBe(webpackDefaultExternals);
   });
 
   it('should create a configuration', () => {
@@ -57,11 +60,13 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     };
     const pathUtils = 'pathUtils';
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackDefaultExternals = ['some/external'];
     const target = {
       name: 'targetName',
       folders: {
         build: 'build-folder',
       },
+      excludeModules: [],
     };
     const entry = {
       [target.name]: ['index.js'],
@@ -94,7 +99,8 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     sut = new WebpackNodeProductionConfiguration(
       events,
       pathUtils,
-      webpackBaseConfiguration
+      webpackBaseConfiguration,
+      webpackDefaultExternals
     );
     result = sut.getConfig(params);
     // Then
@@ -102,6 +108,14 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(webpackNodeUtilsMock.externals).toHaveBeenCalledTimes(1);
+    expect(webpackNodeUtilsMock.externals).toHaveBeenCalledWith(
+      {},
+      false,
+      [
+        ...webpackDefaultExternals,
+        ...target.excludeModules,
+      ]
+    );
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       'webpack-node-production-configuration',
@@ -128,5 +142,6 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(serviceFn).toBeFunction();
     expect(sut).toBeInstanceOf(WebpackNodeProductionConfiguration);
     expect(sut.events).toBe('events');
+    expect(sut.webpackDefaultExternals).toBe('webpackDefaultExternals');
   });
 });


### PR DESCRIPTION
### What does this PR do?

This plugin _"exports"_ two _"sub modules"_:

- `projext-plugin-webpack/express`
- `projext-plugin-webpack/jimpex`

Which are not on the project `package.json`, so if the user bundles a Node target with any of those _"sub modules"_, wepack would try to process the whole plugin and put it on the bundle.... not cool.

So, the first part of this PR defines those paths as _"default externals"_ and add them as exceptions while setting the external dependencies.

And, while changing the implementation of the external dependencies, this PR also implements the new `excludeModules` setting for Node targets (homer0/projext#17)... which is basically another list of exceptions.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
