### PR TITLE
Include the target source folder on the SCSS and CSS rules

### DIFF
--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -163,7 +163,10 @@ class WebpackRulesConfiguration extends ConfigurationFile {
 
     const rules = [{
       test: /\.scss$/i,
-      include: target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
+      include: [
+        new RegExp(target.folders.source),
+        ...target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
+      ],
       use,
     }];
     // Reduce the rules.
@@ -209,7 +212,10 @@ class WebpackRulesConfiguration extends ConfigurationFile {
 
     const rules = [{
       test: /\.css$/i,
-      include: target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
+      include: [
+        new RegExp(target.folders.source),
+        ...target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
+      ],
       use,
     }];
     // Reduce the rules.

--- a/tests/services/configurations/rulesConfiguration.test.js
+++ b/tests/services/configurations/rulesConfiguration.test.js
@@ -85,29 +85,33 @@ describe('services/configurations:rulesConfiguration', () => {
       use: scssUseWithModules,
     };
     // - - Rules
+    const scssInclude = [
+      new RegExp(target.folders.source),
+      ...target.includeModules.map(() => expect.any(RegExp)),
+    ];
     rules.scssRulesForBrowser = [{
       test: expect.any(RegExp),
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: scssInclude,
       use: extractResult,
     }];
     rules.scssRulesForBrowserWithInject = [{
       test: expect.any(RegExp),
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: scssInclude,
       use: scssUseWithInject,
     }];
     rules.scssRulesForBrowserWithModulesAndInject = [{
       test: expect.any(RegExp),
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: scssInclude,
       use: scssUseWithModulesAndInject,
     }];
     rules.scssRulesForNode = [{
       test: expect.any(RegExp),
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: scssInclude,
       use: scssUse,
     }];
     rules.scssRulesForNodeWithModules = [{
       test: expect.any(RegExp),
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: scssInclude,
       use: scssUseWithModules,
     }];
     // - CSS Rules
@@ -124,20 +128,24 @@ describe('services/configurations:rulesConfiguration', () => {
       use: cssUse,
     };
     // - - Rules
+    const cssInclude = [
+      new RegExp(target.folders.source),
+      ...target.includeModules.map(() => expect.any(RegExp)),
+    ];
     rules.cssRulesForBrowser = [{
       test: expect.any(RegExp),
       use: extractResult,
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: cssInclude,
     }];
     rules.cssRulesForBrowserWithInject = [{
       test: expect.any(RegExp),
       use: cssUseWithInject,
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: cssInclude,
     }];
     rules.cssRulesForNode = [{
       test: expect.any(RegExp),
       use: cssUse,
-      include: target.includeModules.map(() => expect.any(RegExp)),
+      include: cssInclude,
     }];
     // - HTML Rules
     rules.htmlRules = [{


### PR DESCRIPTION
### What does this PR do?

Yes... when I updated the SCSS and CSS rules on #17 , I forgot to include the the target source folder, so there was no problem with styles from other modules, but the styles from the target itself weren't being processed.

This is proof that I need to invest more time on the integration tests... soon.

### How should it be tested manually?

Try to build a target :P.