### PR TITLE
Fix CSS and SVG rules

### DIFF
--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -274,6 +274,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
         // `.svg` files inside a `fonts` folder.
         test: /\.svg(\?(v=\d+\.\d+\.\d+|\w+))?$/,
         include: [
+          /\/node_modules\/(?:.*?\/)?fonts\/.*?/i,
           new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
           ...target.includeModules.map((modName) => (
             new RegExp(`/node_modules/${modName}/(?:.*?/)?fonts/.*?`)
@@ -366,6 +367,7 @@ class WebpackRulesConfiguration extends ConfigurationFile {
          */
         /favicon\.\w+$/i,
         // Exclude svg files that were identified as fonts.
+        /\/node_modules\/(?:.*?\/)?fonts\/.*?/i,
         new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
         // Exclude svg files that were identified as fonts on modules being processed.
         ...target.includeModules.map((modName) => (

--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -212,10 +212,6 @@ class WebpackRulesConfiguration extends ConfigurationFile {
 
     const rules = [{
       test: /\.css$/i,
-      include: [
-        new RegExp(target.folders.source),
-        ...target.includeModules.map((name) => new RegExp(`/node_modules/${name}`)),
-      ],
       use,
     }];
     // Reduce the rules.

--- a/tests/services/configurations/rulesConfiguration.test.js
+++ b/tests/services/configurations/rulesConfiguration.test.js
@@ -154,6 +154,7 @@ describe('services/configurations:rulesConfiguration', () => {
         test: expect.any(RegExp),
         include: [
           expect.any(RegExp),
+          expect.any(RegExp),
           ...target.includeModules.map(() => expect.any(RegExp)),
         ],
         use: [{
@@ -209,6 +210,7 @@ describe('services/configurations:rulesConfiguration', () => {
       {
         test: expect.any(RegExp),
         exclude: expect.arrayContaining([
+          expect.any(RegExp),
           expect.any(RegExp),
           expect.any(RegExp),
           ...target.includeModules.map(() => expect.any(RegExp)),

--- a/tests/services/configurations/rulesConfiguration.test.js
+++ b/tests/services/configurations/rulesConfiguration.test.js
@@ -128,24 +128,17 @@ describe('services/configurations:rulesConfiguration', () => {
       use: cssUse,
     };
     // - - Rules
-    const cssInclude = [
-      new RegExp(target.folders.source),
-      ...target.includeModules.map(() => expect.any(RegExp)),
-    ];
     rules.cssRulesForBrowser = [{
       test: expect.any(RegExp),
       use: extractResult,
-      include: cssInclude,
     }];
     rules.cssRulesForBrowserWithInject = [{
       test: expect.any(RegExp),
       use: cssUseWithInject,
-      include: cssInclude,
     }];
     rules.cssRulesForNode = [{
       test: expect.any(RegExp),
       use: cssUse,
-      include: cssInclude,
     }];
     // - HTML Rules
     rules.htmlRules = [{


### PR DESCRIPTION
### What does this PR do?

#### Remove the `include` setting from the CSS rules

The CSS rules don't need one, otherwise if you include a stylesheet from a node module, it would ignore it. The `include` setting should only be on rules that process and transform/transpile files, like the ones for `JS` and `SCSS`.

#### Fix the SVG rules

While I was working on a project with `FontAwesome`, I saw that the font `SVG` file ended on the `images` folder, and that's because the settings for the `/fonts/` folder only apply to directories on your project, no the node modules.

So, I added this `RegExp` to the `include` setting of the fonts rules and the `exclude` setting of the images rules:

```js
/\/node_modules\/(?:.*?\/)?fonts\/.*?/i,
```

It's not perfect, because if the module doesn't have the fonts under a `fonts` folder they will end up on `images`, but it may be helpful on most of the cases.

### How should it be tested manually?

You can test both changes by building a project using the [`font-awesome`](https://yarnpkg.com/en/package/font-awesome) package:

1. Import `font-awesome/css/font-awesome.css` on your project.
2. Build.
3. You shouldn't see any webpack errors regarding the `CSS` file.
4. The `SVG` font file should be on the `fonts` folder and not on the `images` folder.

And of course...

```bash
yarn test
# or
npm test
```
