### PR TITLE
Update Jimple

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "projext": "^3.0.1",
-      "wootils": "^1.1.1",
-      "jimple": "homer0/jimple",
+      "projext": "^3.0.5",
+      "wootils": "^1.1.2",
+      "jimple": "1.5.0",
       "fs-extra": "5.0.0",
       "extend": "3.0.1",
 
@@ -52,7 +52,7 @@
       "jest-ex": "4.0.0",
       "jest-cli": "22.1.4",
       "jasmine-expect": "3.8.3",
-      "jimpex": "^2.1.0",
+      "jimpex": "^2.1.1",
       "esdoc": "1.0.4",
       "esdoc-standard-plugin": "1.0.0",
       "esdoc-node": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext-plugin-webpack",
     "description": "Allows projext to use webpack as a build engine.",
     "homepage": "https://homer0.github.io/projext-plugin-webpack/",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "repository": "homer0/projext-plugin-webpack",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,26 +4945,26 @@ jest-worker@^22.1.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jimpex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-2.1.0.tgz#cb7099ceaa077b7cb8b57d36960558c702536730"
+jimpex@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-2.1.1.tgz#f52d2b85ae513ef720591ac0a7c7446fea4b8e5f"
   dependencies:
     body-parser "1.18.2"
     compression "1.7.1"
     express "4.16.2"
     extend "3.0.1"
     fs-extra "5.0.0"
-    jimple homer0/jimple
+    jimple "1.5.0"
     mime "2.2.0"
     multer "1.3.0"
     node-fetch "1.7.3"
     statuses "1.4.0"
     urijs "1.19.0"
-    wootils "^1.0.5"
+    wootils "^1.1.2"
 
-"jimple@github:homer0/jimple", jimple@homer0/jimple:
-  version "1.4.6"
-  resolved "https://codeload.github.com/homer0/jimple/tar.gz/1f123c2ba1f0aef14de159747455f877f70e0c9d"
+jimple@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jimple/-/jimple-1.5.0.tgz#a964bf4862bb2b488ce3830266a4dd8e8ef1213b"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.3"
@@ -6821,9 +6821,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-projext@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/projext/-/projext-3.0.1.tgz#f9fc983073a3a80e8f225b56c9e15e80974fa6e3"
+projext@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/projext/-/projext-3.0.5.tgz#95f5549d0abceb3d4cddfec247e24d80f173e0c2"
   dependencies:
     babel-cli "6.26.0"
     babel-core "6.26.0"
@@ -6839,12 +6839,12 @@ projext@^3.0.1:
     extend "3.0.1"
     fs-extra "5.0.0"
     glob "7.1.2"
-    jimple homer0/jimple
+    jimple "1.5.0"
     nodemon "1.14.11"
     prompt "1.0.0"
     shelljs "0.8.1"
     watchpack "1.4.0"
-    wootils "^1.1.1"
+    wootils "^1.1.2"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -9056,23 +9056,13 @@ winston@2.1.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-wootils@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.0.5.tgz#8e7c35b8d2167e93c967c6a3c6522712579172e7"
+wootils@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.1.2.tgz#85ce12644b8cf261232a05fad23b1a6d492c731d"
   dependencies:
     colors "1.1.2"
     fs-extra "5.0.0"
-    jimple homer0/jimple
-    statuses "1.4.0"
-    urijs "1.19.0"
-
-wootils@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.1.1.tgz#159e2bdd0f6249b07dce08f8ffc029874b631ca6"
-  dependencies:
-    colors "1.1.2"
-    fs-extra "5.0.0"
-    jimple homer0/jimple
+    jimple "1.5.0"
     statuses "1.4.0"
     urijs "1.19.0"
 


### PR DESCRIPTION
### What does this PR do?

It updates Jimple to the latest version from its original package, removing the custom fork I've been using.

It also updates `wootils`, `jimpex` and `projext`, which were also using the custom fork.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
