### PR TITLE
Require projext v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "projext": "homer0/projext#next",
+      "projext": "^4.0.0",
       "wootils": "^1.3.2",
       "jimple": "1.5.0",
       "fs-extra": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7623,9 +7623,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-projext@homer0/projext#next:
-  version "3.0.5"
-  resolved "https://codeload.github.com/homer0/projext/tar.gz/f53ccfe19c259315ccf3c3e1983b7882ec2fb4fe"
+projext@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/projext/-/projext-4.0.0.tgz#e19f75b24233d44adc712193732bc998d288e760"
   dependencies:
     babel-cli "6.26.0"
     babel-core "6.26.3"


### PR DESCRIPTION
### What does this PR do?

Update the `projext` dependency to the latest published version.

This is breaking because the new `projext` version is breaking.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```