### PR TITLE
Add multiple overwrite paths for the configurations

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -45,7 +45,10 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
   ) {
     super(
       pathUtils,
-      'webpack/browser.development.config.js',
+      [
+        'config/webpack/browser.development.config.js',
+        'config/webpack/browser.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -32,7 +32,10 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
   ) {
     super(
       pathUtils,
-      'webpack/browser.production.config.js',
+      [
+        'config/webpack/browser.production.config.js',
+        'config/webpack/browser.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -30,7 +30,10 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
   ) {
     super(
       pathUtils,
-      'webpack/node.development.config.js',
+      [
+        'config/webpack/node.development.config.js',
+        'config/webpack/node.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -25,7 +25,10 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
   ) {
     super(
       pathUtils,
-      'webpack/node.production.config.js',
+      [
+        'config/webpack/node.production.config.js',
+        'config/webpack/node.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -59,7 +59,10 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'webpack/browser.development.config.js',
+      [
+        'config/webpack/browser.development.config.js',
+        'config/webpack/browser.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -58,7 +58,10 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'webpack/browser.production.config.js',
+      [
+        'config/webpack/browser.production.config.js',
+        'config/webpack/browser.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -44,7 +44,10 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'webpack/node.development.config.js',
+      [
+        'config/webpack/node.development.config.js',
+        'config/webpack/node.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -40,7 +40,10 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'webpack/node.production.config.js',
+      [
+        'config/webpack/node.production.config.js',
+        'config/webpack/node.config.js',
+      ],
       true,
       webpackBaseConfiguration
     );


### PR DESCRIPTION
### What does this PR do?

As the title says, I added extra overwrite paths for the plugin configuration files:

**Browser development configuration:**

- `config/webpack/browser.development.config.js`
- `config/webpack/browser.config.js` <- new

**Browser production configuration:**

- `config/webpack/browser.production.config.js`
- `config/webpack/browser.config.js` <- new


**Node development configuration:**

- `config/webpack/node.development.config.js`
- `config/webpack/node.config.js` <- new

**Node production configuration:**

- `config/webpack/node.production.config.js`
- `config/webpack/node.config.js` <- new

The way it works is projext will take the list of files that can overwrite the configuration and try to find the first one that exists and use it. So, it won't use all, just the first one it finds.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
