### PR TITLE
Implement the new copy setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "compression-webpack-plugin": "1.1.11",
       "uglifyjs-webpack-plugin": "1.2.6",
       "optimize-css-assets-webpack-plugin": "4.0.2",
+      "copy-webpack-plugin": "4.5.2",
 
       "babel-core": "6.26.3",
       "node-sass": "4.9.0",

--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -78,6 +78,11 @@ class WebpackConfiguration {
       entries.unshift('babel-polyfill');
     }
 
+    const copy = [];
+    if (target.is.browser || target.bundle) {
+      copy.push(...this.targets.getFilesToCopy(target, buildType));
+    }
+
     const params = {
       target,
       targetRules: this.targetsFileRules.getRulesForTarget(target),
@@ -86,6 +91,7 @@ class WebpackConfiguration {
       },
       definitions: this._getDefinitions(target, buildType),
       output: target.output[buildType],
+      copy,
       buildType,
     };
 

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
   DefinePlugin,
@@ -89,6 +90,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
   createConfig(params) {
     const {
       definitions,
+      copy,
       entry,
       target,
       output,
@@ -127,6 +129,8 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       new DefinePlugin(definitions),
       // To optimize the SCSS and remove repeated declarations.
       new OptimizeCssAssetsPlugin(),
+      // Copy the files the target specified on its settings.
+      new CopyWebpackPlugin(copy),
       /**
        * If the target doesn't inject the styles on runtime, add the plugin to push them all on
        * a single file.

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -4,6 +4,7 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const { provider } = require('jimple');
 const ConfigurationFile = require('../../abstracts/configurationFile');
@@ -65,6 +66,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
   createConfig(params) {
     const {
       definitions,
+      copy,
       entry,
       target,
       output,
@@ -111,6 +113,8 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       new OptimizeCssAssetsPlugin(),
       // To compress the emitted assets using gzip, if the target is not a library.
       ...(!target.library || target.libraryOptions.compress ? [new CompressionPlugin()] : []),
+      // Copy the files the target specified on its settings.
+      new CopyWebpackPlugin(copy),
       /**
        * If the target doesn't inject the styles on runtime, add the plugin to push them all on
        * a single file.

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -1,4 +1,5 @@
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
@@ -61,7 +62,12 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
    * @return {object}
    */
   createConfig(params) {
-    const { entry, target, output } = params;
+    const {
+      entry,
+      target,
+      output,
+      copy,
+    } = params;
     // By default it doesn't watch the source files.
     let watch = false;
     // Setup the basic plugins.
@@ -70,6 +76,8 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       new NoEmitOnErrorsPlugin(),
       // To optimize the SCSS and remove repeated declarations.
       new OptimizeCssAssetsPlugin(),
+      // Copy the files the target specified on its settings.
+      new CopyWebpackPlugin(copy),
     ];
     // If the target needs to run on development...
     if (target.runOnDevelopment) {

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -1,4 +1,5 @@
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
@@ -51,7 +52,12 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
    * @return {object}
    */
   createConfig(params) {
-    const { entry, target, output } = params;
+    const {
+      entry,
+      target,
+      output,
+      copy,
+    } = params;
     const config = {
       entry,
       output: {
@@ -64,6 +70,8 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
         new NoEmitOnErrorsPlugin(),
         // To optimize the SCSS and remove repeated declarations.
         new OptimizeCssAssetsPlugin(),
+        // Copy the files the target specified on its settings.
+        new CopyWebpackPlugin(copy),
       ],
       target: 'node',
       node: {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -110,6 +110,20 @@
  */
 
 /**
+ * @typedef {function} TargetFileToCopyTransform
+ * @param {string} contents The original contents of the file.
+ * @return {Promise<string,Error>} The updated contents.
+ */
+
+/**
+ * @typedef {Object} TargetFileToCopy
+ * @property {string}                     from      The file origin path.
+ * @property {string}                     to        The file destination path.
+ * @property {?TargetFileToCopyTransform} transform A custom function to modify the contents of
+ *                                                  the file to copy.
+ */
+
+/**
  * @typedef {function} DevMiddlewareGetDirectory
  * @return {string}
  * The build directory of the target implementing the dev middleware.
@@ -187,6 +201,9 @@
  * A dictionary of defined variables that will be replaced on the bundled code.
  * @property {string} buildType
  * The intended built type: `development` or `production`.
+ * @property {Array} copy
+ * A list of {@link TargetFileToCopy} with the information of files that need to be copied during
+ * the bundling process.
  */
 
 /**

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -84,6 +84,11 @@
  */
 
 /**
+ * @external {TargetExtraFile}
+ * https://homer0.github.io/projext/typedef/index.html#static-typedef-TargetExtraFile
+ */
+
+/**
  * @external {TargetConfigurationCreator}
  * https://homer0.github.io/projext/typedef/index.html#static-typedef-TargetConfigurationCreator
  */
@@ -107,20 +112,6 @@
  * @external {ChildProcess}
  * https://nodejs.org/api/child_process.html#child_process_class_childprocess
  * @ignore
- */
-
-/**
- * @typedef {function} TargetFileToCopyTransform
- * @param {string} contents The original contents of the file.
- * @return {Promise<string,Error>} The updated contents.
- */
-
-/**
- * @typedef {Object} TargetFileToCopy
- * @property {string}                     from      The file origin path.
- * @property {string}                     to        The file destination path.
- * @property {?TargetFileToCopyTransform} transform A custom function to modify the contents of
- *                                                  the file to copy.
  */
 
 /**
@@ -202,7 +193,7 @@
  * @property {string} buildType
  * The intended built type: `development` or `production`.
  * @property {Array} copy
- * A list of {@link TargetFileToCopy} with the information of files that need to be copied during
+ * A list of {@link TargetExtraFile} with the information of files that need to be copied during
  * the bundling process.
  */
 

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -10,6 +10,7 @@ jest.mock('mini-css-extract-plugin', () => MiniCssExtractPluginMock);
 jest.mock('html-webpack-plugin');
 jest.mock('script-ext-html-webpack-plugin');
 jest.mock('optimize-css-assets-webpack-plugin');
+jest.mock('copy-webpack-plugin');
 jest.mock('webpack');
 jest.mock('opener');
 jest.unmock('/src/services/configurations/browserDevelopmentConfiguration');
@@ -18,6 +19,7 @@ require('jasmine-expect');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { ProjextWebpackOpenDevServer } = require('/src/plugins');
 
 const {
@@ -33,6 +35,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     HtmlWebpackPlugin.mockReset();
     ScriptExtHtmlWebpackPlugin.mockReset();
     OptimizeCssAssetsPlugin.mockReset();
+    CopyWebpackPlugin.mockReset();
     ProjextWebpackOpenDevServer.mockReset();
   });
 
@@ -106,11 +109,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -158,6 +163,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -207,11 +214,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -256,6 +265,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -306,11 +317,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry: {
@@ -364,6 +377,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -426,11 +441,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -493,6 +510,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -560,11 +579,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -628,6 +649,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -698,11 +721,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -760,6 +785,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(target.devServer.ssl.cert);
     expect(events.reduce).toHaveBeenCalledTimes(1);
@@ -833,11 +860,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -902,6 +931,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(target.devServer.ssl.cert);
     expect(events.reduce).toHaveBeenCalledTimes(1);
@@ -976,11 +1007,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1044,6 +1077,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -1116,11 +1151,13 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1184,6 +1221,8 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -12,6 +12,7 @@ jest.mock('script-ext-html-webpack-plugin');
 jest.mock('compression-webpack-plugin');
 jest.mock('uglifyjs-webpack-plugin');
 jest.mock('optimize-css-assets-webpack-plugin');
+jest.mock('copy-webpack-plugin');
 jest.mock('webpack');
 jest.unmock('/src/services/configurations/browserProductionConfiguration');
 
@@ -21,6 +22,7 @@ const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const {
   WebpackBrowserProductionConfiguration,
@@ -37,6 +39,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     OptimizeCssAssetsPlugin.mockReset();
     UglifyJSPlugin.mockReset();
     CompressionPlugin.mockReset();
+    CopyWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -101,11 +104,13 @@ describe('services/configurations:browserProductionConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -152,6 +157,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -200,11 +207,13 @@ describe('services/configurations:browserProductionConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -248,6 +257,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -296,11 +307,13 @@ describe('services/configurations:browserProductionConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       devtool: 'source-map',
@@ -348,6 +361,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       sourceMap: true,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -394,11 +409,13 @@ describe('services/configurations:browserProductionConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -435,6 +452,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(CompressionPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -481,11 +500,13 @@ describe('services/configurations:browserProductionConfiguration', () => {
       js: 'statics/js/build.js',
       css: 'statics/css/build.css',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       definitions,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -522,6 +543,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -6,10 +6,12 @@ jest.mock('jimple', () => JimpleMock);
 jest.mock('webpack', () => webpackMock);
 jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
 jest.mock('optimize-css-assets-webpack-plugin');
+jest.mock('copy-webpack-plugin');
 jest.unmock('/src/services/configurations/nodeDevelopmentConfiguration');
 
 require('jasmine-expect');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { ProjextWebpackBundleRunner } = require('/src/plugins');
 
 const {
@@ -23,6 +25,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     webpackMock.reset();
     OptimizeCssAssetsPlugin.mockReset();
     ProjextWebpackBundleRunner.mockClear();
+    CopyWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -79,10 +82,12 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     const output = {
       js: 'statics/js/build.js',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -113,6 +118,8 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(result).toEqual(expectedConfig);
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -150,10 +157,12 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     const output = {
       js: 'statics/js/build.js',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -184,6 +193,8 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(result).toEqual(expectedConfig);
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledWith({
       logger: appLogger,

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -6,10 +6,12 @@ jest.mock('jimple', () => JimpleMock);
 jest.mock('webpack', () => webpackMock);
 jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
 jest.mock('optimize-css-assets-webpack-plugin');
+jest.mock('copy-webpack-plugin');
 jest.unmock('/src/services/configurations/nodeProductionConfiguration');
 
 require('jasmine-expect');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const {
   WebpackNodeProductionConfiguration,
@@ -21,6 +23,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     ConfigurationFileMock.reset();
     webpackMock.reset();
     OptimizeCssAssetsPlugin.mockReset();
+    CopyWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -70,10 +73,12 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     const output = {
       js: 'statics/js/build.js',
     };
+    const copy = ['file-to-copy'];
     const params = {
       target,
       entry,
       output,
+      copy,
     };
     const expectedConfig = {
       entry,
@@ -102,6 +107,8 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(result).toEqual(expectedConfig);
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,6 +2111,19 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-webpack-plugin@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.5.2.tgz#d53444a8fea2912d806e78937390ddd7e632ee5c"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    globby "^7.1.1"
+    is-glob "^4.0.0"
+    loader-utils "^1.1.0"
+    minimatch "^3.0.4"
+    p-limit "^1.0.0"
+    serialize-javascript "^1.4.0"
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -4127,6 +4140,17 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 globby@^8.0.1:
   version "8.0.1"
@@ -7069,7 +7093,7 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
-p-limit@^1.1.0:
+p-limit@^1.0.0, p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#48, `copy` was added as a new target setting (check the PR for more information about the feature itself). This PR adds the [`copy-webpack-plugin`](https://yarnpkg.com/en/package/copy-webpack-plugin) plugin in order to implement the new setting.

### How should it be tested manually?

Since projext hasn't been released yet, you would first need to change its version to `homer0/projext#next`.

Now, try copying a file while bundling your target.

And of course...

```bash
yarn test
# or
npm test
```
