### PR TITLE
Implement the new devServer.open option

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -188,6 +188,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       // Push the plugin that logs the dev server statuses and opens the browser.
       config.plugins.push(new ProjextWebpackOpenDevServer(devServerConfig.url, {
         logger: this.appLogger,
+        openBrowser: devServerConfig.open,
       }));
     } else if (target.hot) {
       /**

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -411,6 +411,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       runOnDevelopment: true,
       devServer: {
         port: 2509,
+        open: true,
         host: 'localhost',
         ssl: {},
         proxied: {},
@@ -526,6 +527,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 
@@ -549,6 +551,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       devServer: {
         port: 2509,
         host: 'localhost',
+        open: false,
         ssl: {},
         proxied: {},
         historyApiFallback: true,
@@ -665,6 +668,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 
@@ -690,6 +694,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       devServer: {
         port: 2509,
         host: 'localhost',
+        open: false,
         ssl: {
           key: null,
           cert: 'some/file.crt',
@@ -803,6 +808,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 
@@ -828,6 +834,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       devServer: {
         port: 2509,
         host: 'my-host',
+        open: true,
         ssl: {
           key: null,
           cert: 'some/file.crt',
@@ -949,6 +956,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 
@@ -974,6 +982,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       devServer: {
         port: 2509,
         host: 'localhost',
+        open: false,
         ssl: {},
         proxied: {
           enabled: true,
@@ -1093,6 +1102,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 
@@ -1118,6 +1128,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       devServer: {
         port: 2509,
         host: 'localhost',
+        open: true,
         ssl: {},
         proxied: {
           enabled: true,
@@ -1237,6 +1248,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
+      openBrowser: target.devServer.open,
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

homer0/projext#50 added a new option to decided whether you want to open the browser or not when running the dev server. This plugin implements the new option.

### How should it be tested manually?

Since projext hasn't been released yet, you would first need to change its version to `homer0/projext#next`.

Now, on your project configuration, add a new option on your dev server settings:

```diff
...
devServer: {
  ...,
+  open: false,
},
...
```

If you run your target, it shouldn't open the browser.

And of course:

```bash
yarn test
# or
npm test
```
