### PR TITLE
Require projext ^4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "projext": "^4.0.0",
+      "projext": "^4.1.0",
       "wootils": "^1.3.2",
       "jimple": "1.5.0",
       "fs-extra": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,9 +7647,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-projext@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/projext/-/projext-4.0.0.tgz#e19f75b24233d44adc712193732bc998d288e760"
+projext@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/projext/-/projext-4.1.0.tgz#3be9ef6a5c2726b5774d044da1b836abcf92f323"
   dependencies:
     babel-cli "6.26.0"
     babel-core "6.26.3"


### PR DESCRIPTION
### What does this PR do?

Update the `projext` dependency. This is not breaking because the required version is not breaking, but it allows to use the new features from #43 and #42 .

### How should it be tested manually?

```bash
yarn test
# or
npm test
```