### PR TITLE
Implement the watch mode

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -57,14 +57,15 @@ class WebpackConfiguration {
     this.webpackConfigurations = webpackConfigurations;
   }
   /**
-   * This method generates a complete Webpack configuration for a target.
-   * @param {Target} target    The target information.
-   * @param {string} buildType The intended build type: `production` or `development`.
+   * This method generates a complete webpack configuration for a target.
+   * @param {Target}  target    The target information.
+   * @param {string}  buildType The intended build type: `production` or `development`.
+   * @param {boolean} watch     Whether or not webpack should use the watch mode.
    * @return {Object}
    * @throws {Error} If there's no base configuration for the target type.
    * @throws {Error} If there's no base configuration for the target type and build type.
    */
-  getConfig(target, buildType) {
+  getConfig(target, buildType, watch) {
     const targetType = target.type;
     if (!this.webpackConfigurations[targetType]) {
       throw new Error(`There's no configuration for the selected target type: ${targetType}`);
@@ -93,6 +94,7 @@ class WebpackConfiguration {
       output: target.output[buildType],
       copy,
       buildType,
+      watch,
     };
 
     let config = this.targetConfiguration(

--- a/src/services/building/engine.js
+++ b/src/services/building/engine.js
@@ -50,28 +50,35 @@ class WebpackBuildEngine {
      * @property {string} run    Whether or not to execute the target. This will be like a fake
      *                           boolean as the CLI doesn't support boolean variables, so its value
      *                           will be either `'true'` or `'false'`.
+     * @property {string} watch  Whether or not to watch the target files. This will be like a fake
+     *                           boolean as the CLI doesn't support boolean variables, so its value
+     *                           will be either `'true'` or `'false'`.
      * @access protected
      * @ignore
      */
     this._envVars = {
-      target: 'PROJEXT_WEBPACK_TARGET',
-      type: 'PROJEXT_WEBPACK_BUILD_TYPE',
-      run: 'PROJEXT_WEBPACK_RUN',
+      target: 'PXTWPK_TARGET',
+      type: 'PXTWPK_TYPE',
+      run: 'PXTWPK_RUN',
+      watch: 'PXTWPK_WATCH',
     };
   }
   /**
    * Get the CLI build command to bundle a target.
-   * @param  {Target}  target           The target information.
-   * @param  {string}  buildType        The intended build type: `development` or `production`.
-   * @param  {boolean} [forceRun=false] Force the target to run even if the `runOnDevelopment`
-   *                                    setting is `false`.
+   * @param {Target}  target             The target information.
+   * @param {string}  buildType          The intended build type: `development` or `production`.
+   * @param {boolean} [forceRun=false]   Force the target to run even if the `runOnDevelopment`
+   *                                     setting is `false`.
+   * @param {boolean} [forceWatch=false] Force webpack to use the watch mode even if the `watch`
+   *                                     setting for the required build type is set to `false`.
    * @return {string}
    */
-  getBuildCommand(target, buildType, forceRun = false) {
+  getBuildCommand(target, buildType, forceRun = false, forceWatch = false) {
     const vars = this._getEnvVarsAsString({
       target: target.name,
       type: buildType,
       run: forceRun,
+      watch: forceWatch,
     });
 
     const config = path.join(
@@ -94,13 +101,14 @@ class WebpackBuildEngine {
     return `${vars} ${command} --config ${config} ${options}`;
   }
   /**
-   * Get a Webpack configuration for a target.
-   * @param {Target} target    The target configuration.
-   * @param {string} buildType The intended build type: `development` or `production`.
+   * Get a webpack configuration for a target.
+   * @param {Target}  target    The target configuration.
+   * @param {string}  buildType The intended build type: `development` or `production`.
+   * @param {boolean} watch     Whether or not the webpack watch mode should be enabled.
    * @return {object}
    */
-  getConfiguration(target, buildType) {
-    return this.webpackConfiguration.getConfig(target, buildType);
+  getConfiguration(target, buildType, watch) {
+    return this.webpackConfiguration.getConfig(target, buildType, watch);
   }
   /**
    * Get a Webpack configuration by reading the environment variables sent by the CLI command
@@ -120,7 +128,9 @@ class WebpackBuildEngine {
       target.runOnDevelopment = true;
     }
 
-    return this.getConfiguration(target, type);
+    const watch = vars.watch === 'true' || target.watch[type];
+
+    return this.getConfiguration(target, type, watch);
   }
   /**
    * Given a dictionary with the environment variables purpose and values, this method generates

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -94,6 +94,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       entry,
       target,
       output,
+      watch,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -197,6 +198,12 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
        * required entry to the list.
        */
       hotEntries.push('webpack-hot-middleware/client?reload=true');
+    } else if (watch) {
+      /**
+       * If the target is not running nor it requires HMR (which means is not being served either),
+       * and the watch parameter is `true`, enable the watch mode.
+       */
+      config.watch = true;
     }
     // If there are entries for HMR...
     if (hotEntries.length) {

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -70,6 +70,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       entry,
       target,
       output,
+      watch,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -127,6 +128,11 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
           })]
       ),
     ];
+    // Enable the watch mode if required...
+    if (watch) {
+      config.watch = true;
+    }
+
     // Reduce the configuration
     return this.events.reduce(
       [

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -87,6 +87,9 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       plugins.push(new ProjextWebpackBundleRunner({
         logger: this.appLogger,
       }));
+    } else if (params.watch) {
+      // Enable the watch mode if required.
+      watch = true;
     }
     // Define the rest of the configuration.
     const config = {

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -57,6 +57,7 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
       target,
       output,
       copy,
+      watch,
     } = params;
     const config = {
       entry,
@@ -79,6 +80,7 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
         __dirname: false,
       },
       mode: 'production',
+      watch,
     };
     // Reduce the configuration.
     return this.events.reduce(

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -195,6 +195,8 @@
  * @property {Array} copy
  * A list of {@link TargetExtraFile} with the information of files that need to be copied during
  * the bundling process.
+ * @property {boolean} watch
+ * Whether or not webpack should use the watch mode.
  */
 
 /**

--- a/tests/services/building/engine.test.js
+++ b/tests/services/building/engine.test.js
@@ -61,9 +61,9 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType);
     // Then
-    expect(result).toMatch(/PROJEXT_WEBPACK_TARGET=(?:[\w0-9-_]*?).*?webpack/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_BUILD_TYPE=(?:\w+).*?webpack/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_RUN=(?:true|false).*?webpack/);
+    expect(result).toMatch(/PXTWPK_TARGET=(?:[\w0-9-_]*?).*?webpack/);
+    expect(result).toMatch(/PXTWPK_TYPE=(?:\w+).*?webpack/);
+    expect(result).toMatch(/PXTWPK_RUN=(?:true|false).*?webpack/);
     expect(result).toMatch(new RegExp(`webpack --config ${expectedConfigPath}`));
     expect(result).toMatch(/webpack --config.*?--progress/);
     expect(result).toMatch(/webpack --config.*?--profile/);
@@ -100,9 +100,9 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType);
     // Then
-    expect(result).toMatch(/PROJEXT_WEBPACK_TARGET=(?:[\w0-9-_]*?).*?webpack-dev-server/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_BUILD_TYPE=(?:\w+).*?webpack-dev-server/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_RUN=(?:true|false).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_TARGET=(?:[\w0-9-_]*?).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_TYPE=(?:\w+).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_RUN=(?:true|false).*?webpack-dev-server/);
     expect(result).toMatch(new RegExp(`webpack-dev-server --config ${expectedConfigPath}`));
     expect(result).toMatch(/webpack-dev-server --config.*?--progress/);
     expect(result).toMatch(/webpack-dev-server --config.*?--profile/);
@@ -137,9 +137,9 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType, true);
     // Then
-    expect(result).toMatch(/PROJEXT_WEBPACK_TARGET=(?:[\w0-9-_]*?).*?webpack-dev-server/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_BUILD_TYPE=(?:\w+).*?webpack-dev-server/);
-    expect(result).toMatch(/PROJEXT_WEBPACK_RUN=(?:true|false).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_TARGET=(?:[\w0-9-_]*?).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_TYPE=(?:\w+).*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_RUN=(?:true|false).*?webpack-dev-server/);
     expect(result).toMatch(/webpack-dev-server --config ([\w_\-/]*?)webpack\.config\.js/);
     expect(result).toMatch(/webpack-dev-server --config.*?--progress/);
     expect(result).toMatch(/webpack-dev-server --config.*?--profile/);
@@ -152,6 +152,7 @@ describe('services/building:engine', () => {
     const targets = 'targets';
     const target = 'some-target';
     const buildType = 'production';
+    const watch = false;
     const config = 'config';
     const webpackConfiguration = {
       getConfig: jest.fn(() => config),
@@ -169,11 +170,11 @@ describe('services/building:engine', () => {
       webpackConfiguration,
       webpackPluginInfo
     );
-    result = sut.getConfiguration(target, buildType);
+    result = sut.getConfiguration(target, buildType, watch);
     // Then
     expect(result).toBe(config);
     expect(webpackConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(target, buildType);
+    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(target, buildType, watch);
   });
 
   it('should return a target Webpack configuration', () => {
@@ -181,13 +182,18 @@ describe('services/building:engine', () => {
     const targetName = 'some-target';
     const buildType = 'development';
     const run = false;
+    const watch = false;
     const target = {
       name: targetName,
+      watch: {
+        [buildType]: watch,
+      },
     };
     const envVars = {
-      PROJEXT_WEBPACK_TARGET: targetName,
-      PROJEXT_WEBPACK_BUILD_TYPE: buildType,
-      PROJEXT_WEBPACK_RUN: run.toString(),
+      PXTWPK_TARGET: targetName,
+      PXTWPK_TYPE: buildType,
+      PXTWPK_RUN: run.toString(),
+      PXTWPK_WATCH: watch.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -217,7 +223,7 @@ describe('services/building:engine', () => {
     // Then
     expect(result).toBe(config);
     expect(webpackConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(target, buildType);
+    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(target, buildType, false);
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(targetName);
     expect(environmentUtils.get).toHaveBeenCalledTimes(envVarsNames.length);
@@ -231,13 +237,18 @@ describe('services/building:engine', () => {
     const targetName = 'some-target';
     const buildType = 'development';
     const run = true;
+    const watch = true;
     const target = {
       name: targetName,
+      watch: {
+        [buildType]: watch,
+      },
     };
     const envVars = {
-      PROJEXT_WEBPACK_TARGET: targetName,
-      PROJEXT_WEBPACK_BUILD_TYPE: buildType,
-      PROJEXT_WEBPACK_RUN: run.toString(),
+      PXTWPK_TARGET: targetName,
+      PXTWPK_TYPE: buildType,
+      PXTWPK_RUN: run.toString(),
+      PXTWPK_WATCH: watch.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -267,13 +278,17 @@ describe('services/building:engine', () => {
     // Then
     expect(result).toBe(config);
     expect(webpackConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(Object.assign(
-      {},
-      target,
-      {
-        runOnDevelopment: true,
-      }
-    ), buildType);
+    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(
+      Object.assign(
+        {},
+        target,
+        {
+          runOnDevelopment: true,
+        }
+      ),
+      buildType,
+      watch
+    );
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(targetName);
     expect(environmentUtils.get).toHaveBeenCalledTimes(envVarsNames.length);
@@ -285,9 +300,10 @@ describe('services/building:engine', () => {
   it('should throw an error when getting a configuration without the env variables', () => {
     // Given
     const envVarsNames = [
-      'PROJEXT_WEBPACK_TARGET',
-      'PROJEXT_WEBPACK_BUILD_TYPE',
-      'PROJEXT_WEBPACK_RUN',
+      'PXTWPK_TARGET',
+      'PXTWPK_TYPE',
+      'PXTWPK_RUN',
+      'PXTWPK_WATCH',
     ];
     const environmentUtils = {
       get: jest.fn(),

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -110,12 +110,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -215,12 +217,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -318,12 +322,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = true;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry: {
@@ -373,6 +379,113 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     });
     expect(webpackMock.HotModuleReplacementPluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.NamedModulesPluginMock).toHaveBeenCalledTimes(1);
+    expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-browser-development-configuration',
+        'webpack-browser-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+  });
+
+  it('should create a configuration with watch mode', () => {
+    // Given
+    const appLogger = 'appLogger';
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const webpackPluginInfo = 'webpackPluginInfo';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      paths: {
+        source: 'source-path',
+      },
+      html: {
+        template: 'index.html',
+      },
+      sourceMap: {
+        development: true,
+      },
+      css: {},
+    };
+    const definitions = 'definitions';
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      css: 'statics/css/build.css',
+    };
+    const copy = ['file-to-copy'];
+    const watch = true;
+    const params = {
+      target,
+      definitions,
+      entry,
+      output,
+      copy,
+      watch,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        publicPath: '/',
+      },
+      mode: 'development',
+      devtool: 'source-map',
+      plugins: expect.any(Array),
+      watch: true,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackBrowserDevelopmentConfiguration(
+      appLogger,
+      events,
+      pathUtils,
+      targetsHTML,
+      webpackBaseConfiguration,
+      webpackPluginInfo
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(MiniCssExtractPluginMock.mocks.constructor).toHaveBeenCalledTimes(1);
+    expect(MiniCssExtractPluginMock.mocks.constructor).toHaveBeenCalledWith({
+      filename: output.css,
+    });
+    expect(HtmlWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
+      target.html,
+      {
+        template: target.html.template,
+        inject: 'body',
+      }
+    ));
+    expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledWith({
+      defaultAttribute: 'async',
+    });
     expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
@@ -443,12 +556,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -583,12 +698,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -727,12 +844,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -868,12 +987,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1017,12 +1138,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1163,12 +1286,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -105,12 +105,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -121,6 +123,110 @@ describe('services/configurations:browserProductionConfiguration', () => {
       },
       mode: 'production',
       plugins: expect.any(Array),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackBrowserProductionConfiguration(
+      events,
+      pathUtils,
+      targetsHTML,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(MiniCssExtractPluginMock.mocks.constructor).toHaveBeenCalledTimes(1);
+    expect(MiniCssExtractPluginMock.mocks.constructor).toHaveBeenCalledWith({
+      filename: output.css,
+    });
+    expect(HtmlWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(HtmlWebpackPlugin).toHaveBeenCalledWith(Object.assign(
+      target.html,
+      {
+        template: target.html.template,
+        inject: 'body',
+      }
+    ));
+    expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledWith({
+      defaultAttribute: 'async',
+    });
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
+    expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
+    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
+    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+      sourceMap: false,
+    });
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(CompressionPlugin).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-browser-production-configuration',
+        'webpack-browser-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+    expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+  });
+
+  it('should create a configuration with watch mode', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const targetsHTML = {
+      getFilepath: jest.fn((targetInfo) => targetInfo.html.template),
+    };
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      paths: {
+        source: 'source-path',
+      },
+      html: {
+        template: 'index.html',
+      },
+      sourceMap: {},
+      css: {},
+    };
+    const definitions = 'definitions';
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      css: 'statics/css/build.css',
+    };
+    const copy = ['file-to-copy'];
+    const watch = true;
+    const params = {
+      target,
+      definitions,
+      entry,
+      output,
+      copy,
+      watch,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        publicPath: '/',
+      },
+      mode: 'production',
+      plugins: expect.any(Array),
+      watch,
     };
     let sut = null;
     let result = null;
@@ -208,12 +314,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -308,12 +416,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       devtool: 'source-map',
@@ -410,12 +520,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -501,12 +613,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -83,11 +83,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -158,11 +160,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       js: 'statics/js/build.js',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -199,6 +203,82 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledWith({
       logger: appLogger,
     });
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-node-development-configuration',
+        'webpack-node-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+  });
+
+  it('should create a configuration to watch the target', () => {
+    // Given
+    const appLogger = 'appLogger';
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      paths: {
+        source: 'source-path',
+      },
+      excludeModules: [],
+      runOnDevelopment: false,
+    };
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+    };
+    const copy = ['file-to-copy'];
+    const watch = true;
+    const params = {
+      target,
+      entry,
+      output,
+      copy,
+      watch,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        publicPath: '/',
+      },
+      watch: true,
+      mode: 'development',
+      plugins: expect.any(Array),
+      target: 'node',
+      node: {
+        __dirname: false,
+      },
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackNodeDevelopmentConfiguration(
+      appLogger,
+      events,
+      pathUtils,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -74,11 +74,13 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       js: 'statics/js/build.js',
     };
     const copy = ['file-to-copy'];
+    const watch = false;
     const params = {
       target,
       entry,
       output,
       copy,
+      watch,
     };
     const expectedConfig = {
       entry,
@@ -93,6 +95,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       node: {
         __dirname: false,
       },
+      watch,
     };
     let sut = null;
     let result = null;


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#53 I added support for a watch mode, this PR is the implementation on webpack (plus a minor refactor of the **private** environment variables names).

Since the projext PR is breaking and this one needs that version, this will also be a breaking change.

### How should it be tested manually?

You first need `projext#next` installed, then try using the new `projext watch` command for a bundled target.

And of course...

```bash
npm test
# or
yarn test
```
