### PR TITLE
v6.0.1: Fix URL the browser opens when the Dev Server is being proxied

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext-plugin-webpack",
     "description": "Allows projext to use webpack as a build engine.",
     "homepage": "https://homer0.github.io/projext-plugin-webpack/",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "repository": "homer0/projext-plugin-webpack",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -220,6 +220,8 @@
  * The host used to proxy the dev server.
  * @property {boolean} https
  * Whether or not the proxied host uses `https`.
+ * @property {string} url
+ * The complete URL being used to proxy the dev server.
  */
 
 /**


### PR DESCRIPTION
### What does this PR do?

This issue was caused by #35. When I implemented the custom plugin for handling logging and opening the browser, I completely ignored the `proxied` setting, so if the dev server was being proxied, the browser was still opening the base URL.

This hotfix fixes the issue: It adds a new `url` setting to the `proxied` object `_normalizeTargetDevServerSettings` returns. This URL can change depending on 2 things:

1. If `proxied.enabled` is `true` but no `host` is specified, the `url` will copy the one built for the dev server as if is not being proxied.
2. If `proxied.enabled` is `true` an a `host` was specified, the `url` will be built using that `host`. 

### How should it be tested manually?

You can test it with a configuration like this one:

```js
{
  ...
  devServer: {
    proxied: {
      enabled: true,
      host: 'my-local-domain.com',
      https: true,
    },
    port: 2525,
  },
}
```

When you run your target for development, instead of opening `http://localhost:2525`, it should open `https://my-local-domain.com` (Up to you to setup `my-local-domain` on your computer with SSL enabled :P).

And of course...

```bash
npm test
# or
yarn test
```
