### PR TITLE
TypeScript support

### DIFF
--- a/src/services/configurations/baseConfiguration.js
+++ b/src/services/configurations/baseConfiguration.js
@@ -67,7 +67,7 @@ class WebpackBaseConfiguration extends ConfigurationFile {
     const { rules } = this.webpackRulesConfiguration.getConfig(params);
     const config = {
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         modules: ['./', 'node_modules'],
       },
       module: {

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -110,6 +110,11 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       },
       mode: 'development',
     };
+    // If the target has source maps enabled...
+    if (target.sourceMap.development) {
+      // ...configure the devtool
+      config.devtool = 'source-map';
+    }
     // Reduce the configuration.
     return this.events.reduce(
       [

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -82,6 +82,11 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
       mode: 'production',
       watch: target.watch.production,
     };
+    // If the target has source maps enabled...
+    if (target.sourceMap.production) {
+      // ...configure the devtool
+      config.devtool = 'source-map';
+    }
     // Reduce the configuration.
     return this.events.reduce(
       [

--- a/tests/services/configurations/baseConfiguration.test.js
+++ b/tests/services/configurations/baseConfiguration.test.js
@@ -85,7 +85,7 @@ describe('services/configurations:baseConfiguration', () => {
     };
     const expectedConfig = {
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         modules: ['./', 'node_modules'],
       },
       module: {
@@ -171,7 +171,7 @@ describe('services/configurations:baseConfiguration', () => {
     };
     const expectedConfig = {
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         modules: ['./', 'node_modules'],
       },
       module: {
@@ -262,7 +262,7 @@ describe('services/configurations:baseConfiguration', () => {
     };
     const expectedConfig = {
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         modules: ['./', 'node_modules'],
       },
       module: {
@@ -332,7 +332,7 @@ describe('services/configurations:baseConfiguration', () => {
     const params = { target };
     const expectedConfig = {
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         modules: ['./', 'node_modules'],
       },
       module: {

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -78,6 +78,9 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       watch: {
         development: false,
       },
+      sourceMap: {
+        development: false,
+      },
     };
     const entry = {
       [target.name]: ['index.js'],
@@ -137,6 +140,89 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     );
   });
 
+  it('should create a configuration and enable source maps', () => {
+    // Given
+    const appLogger = 'appLogger';
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      paths: {
+        source: 'source-path',
+      },
+      excludeModules: [],
+      watch: {
+        development: false,
+      },
+      sourceMap: {
+        development: true,
+      },
+    };
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      jsChunks: 'statics/js/build.[name].js',
+    };
+    const copy = ['file-to-copy'];
+    const params = {
+      target,
+      entry,
+      output,
+      copy,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        chunkFilename: output.jsChunks,
+        publicPath: '/',
+      },
+      watch: target.watch.development,
+      mode: 'development',
+      plugins: expect.any(Array),
+      target: 'node',
+      node: {
+        __dirname: false,
+      },
+      devtool: 'source-map',
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackNodeDevelopmentConfiguration(
+      appLogger,
+      events,
+      pathUtils,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(0);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-node-development-configuration',
+        'webpack-node-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+  });
+
   it('should create a configuration to run the target', () => {
     // Given
     const appLogger = 'appLogger';
@@ -160,6 +246,9 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       },
       inspect: {
         enabled: false,
+      },
+      sourceMap: {
+        development: false,
       },
     };
     const entry = {
@@ -244,6 +333,9 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       runOnDevelopment: false,
       watch: {
         development: true,
+      },
+      sourceMap: {
+        development: false,
       },
     };
     const entry = {

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -69,6 +69,9 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       watch: {
         production: false,
       },
+      sourceMap: {
+        production: false,
+      },
     };
     const entry = {
       [target.name]: ['index.js'],
@@ -99,6 +102,83 @@ describe('services/configurations:nodeProductionConfiguration', () => {
         __dirname: false,
       },
       watch: target.watch.production,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackNodeProductionConfiguration(
+      events,
+      pathUtils,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-node-production-configuration',
+        'webpack-node-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+  });
+
+  it('should create a configuration and enable source maps', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      excludeModules: [],
+      watch: {
+        production: false,
+      },
+      sourceMap: {
+        production: true,
+      },
+    };
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      jsChunks: 'statics/js/build.[name].js',
+    };
+    const copy = ['file-to-copy'];
+    const params = {
+      target,
+      entry,
+      output,
+      copy,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        chunkFilename: output.jsChunks,
+        publicPath: '/',
+      },
+      mode: 'production',
+      plugins: expect.any(Array),
+      target: 'node',
+      node: {
+        __dirname: false,
+      },
+      watch: target.watch.production,
+      devtool: 'source-map',
     };
     let sut = null;
     let result = null;


### PR DESCRIPTION
### What does this PR do?

This is the webpack implementation of homer0/projext#64.

The good news is that, since the TypeScript transformation is being handled by Babel and the types declarations are being generated by projext, the only things needed on this plugin were:

- Support for source maps on Node targets.
- Include `.ts` and `.tsx` on the list of extensions to resolve modules.

### How should it be tested manually?

1. Obviously, try bundling a TypeScript target.
2. Try to generate a source map for a Node target.

And...

```bash
yarn test
# or
npm test
```
