### PR TITLE
v7.0.2: fix(project): restore raw-loader v1.0.0 to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext-plugin-webpack",
     "description": "Allows projext to use webpack as a build engine.",
     "homepage": "https://homer0.github.io/projext-plugin-webpack/",
-    "version": "7.0.1",
+    "version": "7.0.2",
     "repository": "homer0/projext-plugin-webpack",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "css-loader": "2.1.1",
       "sass-loader": "7.1.0",
       "style-loader": "0.23.1",
-      "raw-loader": "2.0.0",
+      "raw-loader": "1.0.0",
       "file-loader": "3.0.1",
       "url-loader": "1.1.2",
       "image-webpack-loader": "4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8749,10 +8749,10 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-raw-loader@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-2.0.0.tgz#e2813d9e1e3f80d1bbade5ad082e809679e20c26"
-  integrity sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==
+raw-loader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-1.0.0.tgz#3f9889e73dadbda9a424bce79809b4133ad46405"
+  integrity sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"


### PR DESCRIPTION
### What does this PR do?

On #61 I updated all the dependencies; `raw-loader` was updated from `v1.0.0` to `v2.0.0` as the only breaking I saw was `use ES modules to export` and I assumed it wouldn't change anything for anyone using projext... until I checked a Node project that doesn't use ES modules.

So, this PR restores the version to `v1.0.0` and I'll update to `v2.0.0` on the next major release, which will be soon, whenever the new version of `node-sass`, with the fix for `tar`, gets released.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
