### PR TITLE
refactor(configurations/browser/production): replace uglify with terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "projext": "^6.0.2",
+      "projext": "^6.0.3",
       "wootils": "^2.2.3",
       "jimple": "1.5.0",
       "fs-extra": "7.0.1",
       "extend": "3.0.2",
 
       "webpack": "4.30.0",
-      "webpack-cli": "3.3.0",
+      "webpack-cli": "3.3.1",
       "webpack-dev-server": "3.3.1",
       "mini-css-extract-plugin": "0.6.0",
       "html-webpack-plugin": "3.2.0",
@@ -22,7 +22,7 @@
       "compression-webpack-plugin": "2.0.0",
       "uglifyjs-webpack-plugin": "2.1.2",
       "optimize-css-assets-webpack-plugin": "5.0.1",
-      "copy-webpack-plugin": "5.0.2",
+      "copy-webpack-plugin": "5.0.3",
 
       "@babel/core": "7.4.3",
       "node-sass": "4.11.0",
@@ -46,7 +46,7 @@
     "devDependencies": {
       "eslint": "5.16.0",
       "eslint-config-airbnb-base": "13.1.0",
-      "eslint-plugin-import": "2.17.1",
+      "eslint-plugin-import": "2.17.2",
       "eslint-plugin-node": "8.0.1",
       "@babel/preset-env": "7.4.3",
       "jest-ex": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "html-webpack-plugin": "3.2.0",
       "script-ext-html-webpack-plugin": "2.1.3",
       "compression-webpack-plugin": "2.0.0",
-      "uglifyjs-webpack-plugin": "2.1.2",
+      "terser-webpack-plugin": "1.2.3",
       "optimize-css-assets-webpack-plugin": "5.0.1",
       "copy-webpack-plugin": "5.0.3",
 

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -10,7 +10,7 @@ jest.mock('mini-css-extract-plugin', () => MiniCssExtractPluginMock);
 jest.mock('html-webpack-plugin');
 jest.mock('script-ext-html-webpack-plugin');
 jest.mock('compression-webpack-plugin');
-jest.mock('uglifyjs-webpack-plugin');
+jest.mock('terser-webpack-plugin');
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
 jest.mock('webpack');
@@ -20,7 +20,7 @@ require('jasmine-expect');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
@@ -37,7 +37,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     HtmlWebpackPlugin.mockReset();
     ScriptExtHtmlWebpackPlugin.mockReset();
     OptimizeCssAssetsPlugin.mockReset();
-    UglifyJSPlugin.mockReset();
+    TerserPlugin.mockReset();
     CompressionPlugin.mockReset();
     CopyWebpackPlugin.mockReset();
   });
@@ -126,6 +126,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
     };
     let sut = null;
@@ -158,8 +161,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
@@ -268,7 +271,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(0);
+    expect(TerserPlugin).toHaveBeenCalledTimes(0);
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
@@ -340,6 +343,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
       watch: target.watch.production,
     };
@@ -373,8 +379,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
@@ -450,6 +456,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
     };
     let sut = null;
@@ -479,8 +488,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
@@ -557,6 +566,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
     };
     let sut = null;
@@ -589,8 +601,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: true,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
@@ -664,6 +676,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
     };
     let sut = null;
@@ -686,8 +701,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
@@ -761,6 +776,9 @@ describe('services/configurations:browserProductionConfiguration', () => {
         publicPath: '/',
       },
       mode: 'production',
+      optimization: {
+        minimizer: expect.any(Array),
+      },
       plugins: expect.any(Array),
     };
     let sut = null;
@@ -783,8 +801,8 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(ScriptExtHtmlWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledTimes(1);
     expect(webpackMock.DefinePluginMock).toHaveBeenCalledWith(definitions);
-    expect(UglifyJSPlugin).toHaveBeenCalledTimes(1);
-    expect(UglifyJSPlugin).toHaveBeenCalledWith({
+    expect(TerserPlugin).toHaveBeenCalledTimes(1);
+    expect(TerserPlugin).toHaveBeenCalledWith({
       sourceMap: false,
     });
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,10 +631,10 @@
     "@babel/helper-regex" "^7.4.3"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.3.tgz#332dc6f57b718017c3a8b37b4eea8aa6eeac1187"
-  integrity sha512-rkv8WIvJshA5Ev8iNMGgz5WZkRtgtiPexiT7w5qevGTuT7ZBfM3de9ox1y9JR5/OXb/sWGBbWlHNa7vQKqku3Q==
+"@babel/polyfill@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.0.tgz#90f9d68ae34ac42ab4b4aa03151848f536960218"
+  integrity sha512-bVsjsrtsDflIHp5I6caaAa2V25Kzn50HKPL6g3X0P0ni1ks+58cPB8Mz6AOKVuRPgaVdq/OwEUc/1vKqX+Mo4A==
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
@@ -2027,7 +2027,7 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-cacache@^11.0.2, cacache@^11.2.0, cacache@^11.3.1:
+cacache@^11.0.2, cacache@^11.2.0, cacache@^11.3.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
   integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
@@ -2676,21 +2676,22 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-webpack-plugin@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.2.tgz#56186dfddbf9aa1b29c97fa4c796c1be98870da4"
-  integrity sha512-7nC7EynPrnBTtBwwbG1aTqrfNS1aTb9eEjSmQDqFtKAsJrR3uDb+pCDIFT2LzhW+SgGJxQcYzThrmXzzZ720uw==
+copy-webpack-plugin@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.3.tgz#2179e3c8fd69f13afe74da338896f1f01a875b5c"
+  integrity sha512-PlZRs9CUMnAVylZq+vg2Juew662jWtwOXOqH4lbQD9ZFhRG9R7tVStOgHt21CBGVq7k5yIJaz8TXDLSjV+Lj8Q==
   dependencies:
-    cacache "^11.3.1"
-    find-cache-dir "^2.0.0"
+    cacache "^11.3.2"
+    find-cache-dir "^2.1.0"
     glob-parent "^3.1.0"
     globby "^7.1.1"
-    is-glob "^4.0.0"
-    loader-utils "^1.1.0"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
     minimatch "^3.0.4"
     normalize-path "^3.0.0"
-    p-limit "^2.1.0"
-    serialize-javascript "^1.4.0"
+    p-limit "^2.2.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
     webpack-log "^2.0.0"
 
 core-js-compat@^3.0.0:
@@ -3808,10 +3809,10 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.1"
 
-eslint-plugin-import@2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.1.tgz#b888feb4d9b3ee155113c8dccdd4bec5db33bdf4"
-  integrity sha512-lzD9uvRvW4MsHzIOMJEDSb5MOV9LzgxRPBaovvOhJqzgxRHYfGy9QOrMuwHIh5ehKFJ7Z3DcrcGKDQ0IbP0EdQ==
+eslint-plugin-import@2.17.2:
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
+  integrity sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==
   dependencies:
     array-includes "^3.0.3"
     contains-path "^0.1.0"
@@ -4353,7 +4354,7 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -5649,7 +5650,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -7830,7 +7831,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.1.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
@@ -8546,10 +8547,10 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projext@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/projext/-/projext-6.0.2.tgz#b3e6a2e02dba463f869393972c069a6fb4f5c52e"
-  integrity sha512-Ld4KrZ8laZ1boIxtOU4RqDtSg3/wAoOC+0U4HEIzjVGQpeqjcN4hvPMguvSFQ489z8GPJL82LfZi8DEKANiHIA==
+projext@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/projext/-/projext-6.0.3.tgz#3e5fe845a60d6d867170987df6ed9052a091a293"
+  integrity sha512-ty7Yx1iYuHUqjLYxoIW8407A4UIKtPWvj5yIxQ1M9gw5xzqmpdZyD8iz0XBA7JlhW8jXKpvzDawafTyvYrfERA==
   dependencies:
     "@babel/cli" "7.4.3"
     "@babel/core" "7.4.3"
@@ -8558,7 +8559,7 @@ projext@^6.0.2:
     "@babel/plugin-proposal-object-rest-spread" "7.4.3"
     "@babel/plugin-syntax-dynamic-import" "7.2.0"
     "@babel/plugin-transform-runtime" "7.4.3"
-    "@babel/polyfill" "7.4.3"
+    "@babel/polyfill" "7.4.0"
     "@babel/preset-env" "7.4.3"
     "@babel/preset-flow" "7.0.0"
     "@babel/preset-typescript" "7.3.3"
@@ -9422,6 +9423,11 @@ serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
   integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
+
+serialize-javascript@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -10725,10 +10731,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-cli@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.0.tgz#55c8a74cae1e88117f9dda3a801c7272e93ca318"
-  integrity sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==
+webpack-cli@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.1.tgz#98b0499c7138ba9ece8898bd99c4f007db59909d"
+  integrity sha512-c2inFU7SM0IttEgF7fK6AaUsbBnORRzminvbyRKS+NlbQHVZdCtzKBlavRL5359bFsywXGRAItA5di/IruC8mg==
   dependencies:
     chalk "^2.4.1"
     cross-spawn "^6.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10128,7 +10128,7 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-terser-webpack-plugin@^1.1.0:
+terser-webpack-plugin@1.2.3, terser-webpack-plugin@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
   integrity sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==
@@ -10377,27 +10377,13 @@ uglify-js@3.4.x:
     commander "~2.19.0"
     source-map "~0.6.1"
 
-uglify-js@^3.0.0, uglify-js@^3.1.4:
+uglify-js@^3.1.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.4.tgz#4a64d57f590e20a898ba057f838dcdfb67a939b9"
   integrity sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz#70e5c38fb2d35ee887949c2a0adb2656c23296d5"
-  integrity sha512-G1fJx2uOAAfvdZ77SVCzmFo6mv8uKaHoZBL9Qq/ciC8r6p0ANOL1uY85fIUiyWXKw5RzAaJYZfNSL58Or2hQ0A==
-  dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^2.0.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-js "^3.0.0"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 unbzip2-stream@^1.0.9:
   version "1.3.3"


### PR DESCRIPTION
### What does this PR do?

It replaces [uglifyjs-webpack-plugin](https://npmjs.com/package/uglifyjs-webpack-plugin) with [terser-webpack-plugin](https://npmjs.com/package/terser-webpack-plugin) for bundle minification/uglification. The main reason is that `uglifyjs` doesn't support ES6+ code, and in the future, webpack will include `terser` as its default minification "engine".

Also, instead of adding `terser` to the plugins list, I'm adding it on the new `optimization` object, like the webpack documentation recommends.

This is breaking for plugin developers and in case you are using events to modify the configuration.

### How should it be tested manually?

For an end user that is not modifying the configuration, the change is not breaking, so just install the branch and build for production, the minification should happen the same way as before.

And of course...

```bash
yarn test
# or
npm test
```
