### PR TITLE
chore(project): update raw-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "css-loader": "2.1.1",
       "sass-loader": "7.1.0",
       "style-loader": "0.23.1",
-      "raw-loader": "1.0.0",
+      "raw-loader": "2.0.0",
       "file-loader": "3.0.1",
       "url-loader": "1.1.2",
       "image-webpack-loader": "4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8750,10 +8750,10 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-raw-loader@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-1.0.0.tgz#3f9889e73dadbda9a424bce79809b4133ad46405"
-  integrity sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==
+raw-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-2.0.0.tgz#e2813d9e1e3f80d1bbade5ad082e809679e20c26"
+  integrity sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"


### PR DESCRIPTION
### What does this PR do?

As the title and the only commit say, it updates the [raw-loader](https://www.npmjs.com/package/raw-loader). The reason this is being done on a single PR is because the `raw-loader@v2` is breaking to the previous versions, as it started exporting the files using ES modules syntax.

If you are using `require('file.html')` you'll now have to do `require('file.html').default`... or, you know, use ES modules syntax (`import`).

### How should it be tested manually?

1. Import an HTML file using `import`.
2. Import an HTML file using `require` and `default`.
3. And of course...

```bash
yarn test
# or
npm test
```
