### PR TITLE
v8.0.3: fix(project): fix terser package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext-plugin-webpack",
     "description": "Allows projext to use webpack as a build engine.",
     "homepage": "https://homer0.github.io/projext-plugin-webpack/",
-    "version": "8.0.2",
+    "version": "8.0.3",
     "repository": "homer0/projext-plugin-webpack",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "html-webpack-plugin": "^3.2.0",
       "script-ext-html-webpack-plugin": "^2.1.3",
       "compression-webpack-plugin": "2.0.0",
-      "terser-webpack-plugin": "^1.3.0",
+      "terser-webpack-plugin": "1.3.0",
       "optimize-css-assets-webpack-plugin": "^5.0.1",
       "copy-webpack-plugin": "^5.0.3",
 
@@ -39,6 +39,8 @@
 
       "webpack-dev-middleware": "^3.7.0",
       "webpack-hot-middleware": "^2.25.0",
+
+      "terser": "4.0.0",
 
       "opener": "^1.5.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9491,7 +9491,7 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.3.0:
+terser-webpack-plugin@1.3.0, terser-webpack-plugin@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz#69aa22426299f4b5b3775cbed8cb2c5d419aa1d4"
   integrity sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==
@@ -9507,7 +9507,7 @@ terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.3.0:
     webpack-sources "^1.3.0"
     worker-farm "^1.7.0"
 
-terser@^4.0.0:
+terser@4.0.0, terser@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.0.0.tgz#ef356f6f359a963e2cc675517f21c1c382877374"
   integrity sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==


### PR DESCRIPTION
### What does this PR do?

Since #63 , the project is using [`terser-webpack-plugin`](http://yarnpkg.com/en/package/terser-webpack-plugin) to minify the files. The plugin requires [`terser@^4.0.0`](http://yarnpkg.com/en/package/terser), the core library that actually does the whole thing.

A few hours ago, `terser@4.0.1` was released... with a bug on the source map generation; this causes webpack to silently exit without any error nor notification.

Forcing the project to install `terser@4.0.0` seems to fix the issue.

I'll keep an eye for when it gets fixed and I'll remove the dependency.

### How should it be tested manually?

Try to build a project for production using `master` and this branch.