### PR TITLE
feat(services/building/configuration): load targets dotenv files

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -134,10 +134,18 @@ class WebpackConfiguration {
    * @ignore
    */
   _getDefinitions(target, env) {
-    const definitions = {
-      'process.env.NODE_ENV': `'${env}'`,
-      [this.buildVersion.getDefinitionVariable()]: JSON.stringify(this.buildVersion.getVersion()),
-    };
+    const targetVariables = this.targets.loadTargetDotEnvFile(target, env);
+    const definitions = Object.keys(targetVariables).reduce(
+      (current, variableName) => Object.assign({}, current, {
+        [`process.env.${variableName}`]: JSON.stringify(targetVariables[variableName]),
+      }),
+      {}
+    );
+
+    definitions['process.env.NODE_ENV'] = `'${env}'`;
+    definitions[this.buildVersion.getDefinitionVariable()] = JSON.stringify(
+      this.buildVersion.getVersion()
+    );
 
     if (
       target.is.browser &&

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -126,7 +126,13 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const envVarName = 'ROSARIO';
+    const envVarValue = 'Charito';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({
+        [envVarName]: envVarValue,
+      })),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -191,6 +197,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -199,6 +207,7 @@ describe('services/building:configuration', () => {
         [target.name]: [path.join(target.paths.source, target.entry[buildType])],
       },
       definitions: {
+        [`process.env.${envVarName}`]: `"${envVarValue}"`,
         'process.env.NODE_ENV': `'${buildType}'`,
         [versionVariable]: `"${version}"`,
       },
@@ -234,6 +243,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -300,6 +310,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -347,6 +359,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -411,6 +424,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -457,6 +472,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
       getBrowserTargetConfiguration: jest.fn(() => targetBrowserConfig),
     };
     const targetRules = 'target-rule';
@@ -521,6 +537,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -566,7 +584,9 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -634,6 +654,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -677,7 +699,9 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -747,6 +771,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,
@@ -787,7 +813,9 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = '';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -859,6 +887,8 @@ describe('services/building:configuration', () => {
       `webpack/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       target,


### PR DESCRIPTION
### What does this PR do?

> This is the implementation of homer0/projext#80.
> 
> It add supports for targets' `.env` files.

When creating the definitions that end up on `webpack.DefinePlugin`, `WebpackConfiguration` will now include the variables from the `.env` files.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

Create an `.env.[target-name]` file with a variable declaration and then log it on your target using `process.env.[VARIABLE-NAME]`.

And, of course...

```bash
yarn test
# or
npm test
```