### PR TITLE
feat(project): watch files involved in the creation of a browser target configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "terser-webpack-plugin": "^1.3.0",
       "optimize-css-assets-webpack-plugin": "^5.0.3",
       "copy-webpack-plugin": "^5.0.3",
+      "extra-watch-webpack-plugin": "^1.0.3",
 
       "@babel/core": "7.5.5",
       "node-sass": "^4.12.0",

--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -97,11 +97,11 @@ class WebpackConfiguration {
     }
 
     const definitions = this._getDefinitions(target, buildType);
-    const watch = [];
+    const additionalWatch = [];
     if (target.is.browser && target.configuration && target.configuration.enabled) {
       const browserConfig = this.targets.getBrowserTargetConfiguration(target);
       definitions[target.configuration.defineOn] = JSON.stringify(browserConfig.configuration);
-      watch.push(...browserConfig.files);
+      additionalWatch.push(...browserConfig.files);
     }
 
     const params = {
@@ -114,7 +114,7 @@ class WebpackConfiguration {
       output,
       copy,
       buildType,
-      watch,
+      additionalWatch,
     };
 
     let config = this.targetConfiguration(

--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -96,16 +96,25 @@ class WebpackConfiguration {
       output.jsChunks = this._generateChunkName(output.js);
     }
 
+    const definitions = this._getDefinitions(target, buildType);
+    const watch = [];
+    if (target.is.browser && target.configuration && target.configuration.enabled) {
+      const browserConfig = this.targets.getBrowserTargetConfiguration(target);
+      definitions[target.configuration.defineOn] = JSON.stringify(browserConfig.configuration);
+      watch.push(...browserConfig.files);
+    }
+
     const params = {
       target,
       targetRules: this.targetsFileRules.getRulesForTarget(target),
       entry: {
         [target.name]: entries,
       },
-      definitions: this._getDefinitions(target, buildType),
+      definitions,
       output,
       copy,
       buildType,
+      watch,
     };
 
     let config = this.targetConfiguration(
@@ -146,16 +155,6 @@ class WebpackConfiguration {
     definitions[this.buildVersion.getDefinitionVariable()] = JSON.stringify(
       this.buildVersion.getVersion()
     );
-
-    if (
-      target.is.browser &&
-      target.configuration &&
-      target.configuration.enabled
-    ) {
-      definitions[target.configuration.defineOn] = JSON.stringify(
-        this.targets.getBrowserTargetConfiguration(target)
-      );
-    }
 
     return definitions;
   }

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -4,6 +4,7 @@ const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
   DefinePlugin,
@@ -94,6 +95,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       entry,
       target,
       output,
+      additionalWatch,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -142,6 +144,12 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
           [new MiniCssExtractPlugin({
             filename: output.css,
           })]
+      ),
+      // If there are additionals files to watch, add the plugin for it.
+      ...(
+        additionalWatch.length ?
+          [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+          []
       ),
     ];
     // Define a list of extra entries that may be need depending on the target HMR configuration.

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const { provider } = require('jimple');
 const ConfigurationFile = require('../../abstracts/configurationFile');
@@ -70,6 +71,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       entry,
       target,
       output,
+      additionalWatch,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -137,6 +139,12 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
           [new MiniCssExtractPlugin({
             filename: output.css,
           })]
+      ),
+      // If there are additionals files to watch, add the plugin for it.
+      ...(
+        additionalWatch.length ?
+          [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+          []
       ),
     ];
     // Enable the watch mode if required...

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -1,5 +1,6 @@
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
@@ -67,6 +68,7 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       target,
       output,
       copy,
+      additionalWatch,
     } = params;
     // By default it doesn't watch the source files.
     let watch = false;
@@ -78,6 +80,12 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       new OptimizeCssAssetsPlugin(),
       // Copy the files the target specified on its settings.
       new CopyWebpackPlugin(copy),
+      // If there are additionals files to watch, add the plugin for it.
+      ...(
+        additionalWatch.length ?
+          [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+          []
+      ),
     ];
     // If the target needs to run on development...
     if (target.runOnDevelopment) {

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -1,5 +1,6 @@
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
@@ -57,6 +58,7 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
       target,
       output,
       copy,
+      additionalWatch,
     } = params;
     const config = {
       entry,
@@ -73,6 +75,12 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
         new OptimizeCssAssetsPlugin(),
         // Copy the files the target specified on its settings.
         new CopyWebpackPlugin(copy),
+        // If there are additionals files to watch, add the plugin for it.
+        ...(
+          additionalWatch.length ?
+            [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+            []
+        ),
       ],
       target: 'node',
       node: {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -202,7 +202,7 @@
  * @property {Array} copy
  * A list of {@link TargetExtraFile} with the information of files that need to be copied during
  * the bundling process.
- * @property {Array} watch
+ * @property {Array} additionalWatch
  * A list of additional paths webpack should watch for in order to restart the bundle.
  */
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -202,6 +202,8 @@
  * @property {Array} copy
  * A list of {@link TargetExtraFile} with the information of files that need to be copied during
  * the bundling process.
+ * @property {Array} watch
+ * A list of additional paths webpack should watch for in order to restart the bundle.
  */
 
 /**

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -216,7 +216,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -329,7 +329,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: filesToCopy,
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -442,7 +442,7 @@ describe('services/building:configuration', () => {
       output: target.output[buildType],
       targetRules,
       copy: filesToCopy,
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -563,7 +563,7 @@ describe('services/building:configuration', () => {
       },
       targetRules,
       copy: filesToCopy,
-      watch: targetBrowserConfigFiles,
+      additionalWatch: targetBrowserConfigFiles,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -683,7 +683,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -798,7 +798,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -915,7 +915,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
-      watch: [],
+      additionalWatch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -216,6 +216,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -328,6 +329,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: filesToCopy,
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -440,6 +442,7 @@ describe('services/building:configuration', () => {
       output: target.output[buildType],
       targetRules,
       copy: filesToCopy,
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -469,11 +472,15 @@ describe('services/building:configuration', () => {
     const targetBrowserConfig = {
       someProp: 'someValue',
     };
+    const targetBrowserConfigFiles = ['some-config-file'];
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
       loadTargetDotEnvFile: jest.fn(() => ({})),
-      getBrowserTargetConfiguration: jest.fn(() => targetBrowserConfig),
+      getBrowserTargetConfiguration: jest.fn(() => ({
+        configuration: targetBrowserConfig,
+        files: targetBrowserConfigFiles,
+      })),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -556,6 +563,7 @@ describe('services/building:configuration', () => {
       },
       targetRules,
       copy: filesToCopy,
+      watch: targetBrowserConfigFiles,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -675,6 +683,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -789,6 +798,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -905,6 +915,7 @@ describe('services/building:configuration', () => {
       }),
       targetRules,
       copy: [],
+      watch: [],
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -11,6 +11,7 @@ jest.mock('html-webpack-plugin');
 jest.mock('script-ext-html-webpack-plugin');
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
+jest.mock('extra-watch-webpack-plugin');
 jest.mock('webpack');
 jest.mock('opener');
 jest.unmock('/src/services/configurations/browserDevelopmentConfiguration');
@@ -20,6 +21,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { ProjextWebpackOpenDevServer } = require('/src/plugins');
 
 const {
@@ -36,6 +38,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     ScriptExtHtmlWebpackPlugin.mockReset();
     OptimizeCssAssetsPlugin.mockReset();
     CopyWebpackPlugin.mockReset();
+    ExtraWatchWebpackPlugin.mockReset();
     ProjextWebpackOpenDevServer.mockReset();
   });
 
@@ -114,12 +117,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -170,6 +175,10 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledWith({
+      files: additionalWatch,
+    });
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -224,12 +233,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -277,6 +288,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -332,12 +344,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry: {
@@ -394,6 +408,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -448,12 +463,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -504,6 +521,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -573,12 +591,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -644,6 +664,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -719,12 +740,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -791,6 +814,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -869,12 +893,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -935,6 +961,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(target.devServer.ssl.cert);
     expect(events.reduce).toHaveBeenCalledTimes(1);
@@ -1016,12 +1043,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `https://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1089,6 +1118,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(target.devServer.ssl.cert);
     expect(events.reduce).toHaveBeenCalledTimes(1);
@@ -1171,12 +1201,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedConfig = {
@@ -1243,6 +1275,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -1323,12 +1356,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedProxiedURL = `http://${target.devServer.proxied.host}`;
@@ -1396,6 +1431,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -1476,12 +1512,14 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedURL = `http://${target.devServer.host}:${target.devServer.port}`;
     const expectedProxiedURL = `https://${target.devServer.proxied.host}`;
@@ -1549,6 +1587,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -13,6 +13,7 @@ jest.mock('compression-webpack-plugin');
 jest.mock('terser-webpack-plugin');
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
+jest.mock('extra-watch-webpack-plugin');
 jest.mock('webpack');
 jest.unmock('/src/services/configurations/browserProductionConfiguration');
 
@@ -23,6 +24,7 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 
 const {
   WebpackBrowserProductionConfiguration,
@@ -40,6 +42,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     TerserPlugin.mockReset();
     CompressionPlugin.mockReset();
     CopyWebpackPlugin.mockReset();
+    ExtraWatchWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -110,12 +113,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -168,6 +173,10 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledWith({
+      files: additionalWatch,
+    });
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -220,12 +229,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -275,6 +286,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -327,12 +339,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -386,6 +400,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -440,12 +455,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -495,6 +512,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -549,12 +567,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       devtool: 'source-map',
@@ -608,6 +628,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -660,12 +681,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -708,6 +731,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -760,12 +784,14 @@ describe('services/configurations:browserProductionConfiguration', () => {
       css: 'statics/css/build.css',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       definitions,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -808,6 +834,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(CompressionPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -7,11 +7,13 @@ jest.mock('webpack', () => webpackMock);
 jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
+jest.mock('extra-watch-webpack-plugin');
 jest.unmock('/src/services/configurations/nodeDevelopmentConfiguration');
 
 require('jasmine-expect');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { ProjextWebpackBundleRunner } = require('/src/plugins');
 
 const {
@@ -26,6 +28,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     OptimizeCssAssetsPlugin.mockReset();
     ProjextWebpackBundleRunner.mockClear();
     CopyWebpackPlugin.mockReset();
+    ExtraWatchWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -90,11 +93,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -128,6 +133,10 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledWith({
+      files: additionalWatch,
+    });
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -172,11 +181,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -211,6 +222,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
@@ -259,11 +271,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -297,6 +311,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackBundleRunner).toHaveBeenCalledWith({
       logger: appLogger,
@@ -346,11 +361,13 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -384,6 +401,7 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -7,11 +7,13 @@ jest.mock('webpack', () => webpackMock);
 jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
+jest.mock('extra-watch-webpack-plugin');
 jest.unmock('/src/services/configurations/nodeProductionConfiguration');
 
 require('jasmine-expect');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 
 const {
   WebpackNodeProductionConfiguration,
@@ -24,6 +26,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     webpackMock.reset();
     OptimizeCssAssetsPlugin.mockReset();
     CopyWebpackPlugin.mockReset();
+    ExtraWatchWebpackPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -81,11 +84,13 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -118,6 +123,10 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledWith({
+      files: additionalWatch,
+    });
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [
@@ -157,11 +166,13 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       jsChunks: 'statics/js/build.[name].js',
     };
     const copy = ['file-to-copy'];
+    const additionalWatch = [];
     const params = {
       target,
       entry,
       output,
       copy,
+      additionalWatch,
     };
     const expectedConfig = {
       entry,
@@ -195,6 +206,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,7 +4080,7 @@ extglob@^2.0.4:
 
 extra-watch-webpack-plugin@^1.0.3:
   version "1.0.3"
-  resolved "http://local.npm/extra-watch-webpack-plugin/-/extra-watch-webpack-plugin-1.0.3.tgz#774248f4ac590159bd5878d862d77afce697d7cc"
+  resolved "https://registry.yarnpkg.com/extra-watch-webpack-plugin/-/extra-watch-webpack-plugin-1.0.3.tgz#774248f4ac590159bd5878d862d77afce697d7cc"
   integrity sha512-ZScQdMH6hNofRRN6QMQFg+aa5vqimfBgnPXmRDhdaLpttT6hrzpY9Oyren3Gh/FySPrgsvKCNbx/NFA7XNdIsg==
   dependencies:
     glob "^7.1.2"
@@ -8893,7 +8893,7 @@ sax@^1.1.4, sax@^1.2.4, sax@~1.2.4:
 
 schema-utils@^0.4.0:
   version "0.4.7"
-  resolved "http://local.npm/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
   dependencies:
     ajv "^6.1.0"
@@ -9208,9 +9208,9 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     urix "^0.1.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
-  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -10276,9 +10276,9 @@ webpack-log@^2.0.0:
     uuid "^3.3.2"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
-  integrity sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.0.tgz#be93d629601aa3ea48e8686ee4d78d9c4e706061"
+  integrity sha512-1e4Cxgqfl8vnDhXMMpegX7JWWP7HwV8Kp8/Oefs6EG52bRtOR9vuOXM1Gl1vy6NwHfUxHeuR6ElD4HamuRPO0A==
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,16 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extra-watch-webpack-plugin@^1.0.3:
+  version "1.0.3"
+  resolved "http://local.npm/extra-watch-webpack-plugin/-/extra-watch-webpack-plugin-1.0.3.tgz#774248f4ac590159bd5878d862d77afce697d7cc"
+  integrity sha512-ZScQdMH6hNofRRN6QMQFg+aa5vqimfBgnPXmRDhdaLpttT6hrzpY9Oyren3Gh/FySPrgsvKCNbx/NFA7XNdIsg==
+  dependencies:
+    glob "^7.1.2"
+    is-glob "^4.0.0"
+    lodash.uniq "^4.5.0"
+    schema-utils "^0.4.0"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -8801,6 +8811,14 @@ sax@^1.1.4, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+schema-utils@^0.4.0:
+  version "0.4.7"
+  resolved "http://local.npm/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR do?

> This is the implementation of homer0/projext#82.

It watches the files involved on the creation of a "browser target configuration", so if they're modified, webpack will reload the bundle.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

Create a browser target that uses a configuration file and try updating it while projext runs the target, the bundle should be reloaded.

And, of course...

```bash
yarn test
# or
npm test
```