### PR TITLE
 fix(services/configurations/rulesConfiguration): use the css-loader new options

### DIFF
--- a/src/services/configurations/rulesConfiguration.js
+++ b/src/services/configurations/rulesConfiguration.js
@@ -160,10 +160,10 @@ class WebpackRulesConfiguration extends ConfigurationFile {
     };
     // If the target uses CSS modules...
     if (target.css.modules) {
-      // ...enable them on the CSS loader configuration.
-      cssLoaderConfig.modules = true;
-      // Add the modules name format.
-      cssLoaderConfig.localIdentName = '[name]__[local]___[hash:base64:5]';
+      // ...enable them on the CSS loader configuration and add the name format.
+      cssLoaderConfig.modules = {
+        localIdentName: '[name]__[local]___[hash:base64:5]',
+      };
     }
 
     let eventName = 'webpack-scss-rules-configuration-for-node';

--- a/tests/services/configurations/rulesConfiguration.test.js
+++ b/tests/services/configurations/rulesConfiguration.test.js
@@ -107,8 +107,9 @@ describe('services/configurations:rulesConfiguration', () => {
         loader: 'css-loader',
         options: {
           importLoaders: 2,
-          modules: true,
-          localIdentName: '[name]__[local]___[hash:base64:5]',
+          modules: {
+            localIdentName: '[name]__[local]___[hash:base64:5]',
+          },
         },
       },
       'resolve-url-loader',


### PR DESCRIPTION
### What does this PR do?

Fixes the implementation of the `css-loader` for CSS modules.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

If you tried to use CSS modules before this fix, the loader would throw an error; after installing this branch, everything should work as it was.

And, of course...

```bash
yarn test
# or
npm test
```