### PR TITLE
feat(projext): implement the bundle analyzer plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "webpack-dev-middleware": "^3.7.0",
     "webpack-hot-middleware": "^2.25.0",
 
+    "webpack-bundle-analyzer": "^3.4.1",
+
     "terser": "^4.2.1",
 
     "opener": "^1.5.1"

--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -110,6 +110,11 @@ class WebpackConfiguration {
       copy,
       buildType,
       additionalWatch,
+      /**
+       * The reason we are taking this property is because it's not part of the `Target` entity,
+       * but it may be injected by the build engine.
+       */
+      analyze: !!target.analyze,
     };
 
     let config = this.targetConfiguration(

--- a/src/services/building/engine.js
+++ b/src/services/building/engine.js
@@ -56,6 +56,10 @@ class WebpackBuildEngine {
      * @property {string} inspect Whether or not to enable the Node inspector. This will be like a
      *                            fake boolean as the CLI doesn't support boolean variables, so its
      *                            value will be either `'true'` or `'false'`.
+     * @property {string} analyze Whether or not to enable the bundle analyzer. This will be like a
+     *                            fake boolean as the CLI doesn't support boolean variables, so its
+     *                            value will be either `'true'` or `'false'`.
+     *
      * @access protected
      * @ignore
      */
@@ -65,6 +69,7 @@ class WebpackBuildEngine {
       run: 'PXTWPK_RUN',
       watch: 'PXTWPK_WATCH',
       inspect: 'PXTWPK_INSPECT',
+      analyze: 'PXTWPK_ANALYZE',
     };
   }
   /**
@@ -77,6 +82,7 @@ class WebpackBuildEngine {
    *                                       setting for the required build type is set to `false`.
    * @param {boolean} [forceInspect=false] Enables the Node inspector even if the target setting
    *                                       is set to `false`.
+   * @param {boolean} [forceAnalyze=false] Enables the bundle analyzer.
    * @return {string}
    */
   getBuildCommand(
@@ -84,7 +90,8 @@ class WebpackBuildEngine {
     buildType,
     forceRun = false,
     forceWatch = false,
-    forceInspect = false
+    forceInspect = false,
+    forceAnalyze = false
   ) {
     const vars = this._getEnvVarsAsString({
       target: target.name,
@@ -92,6 +99,7 @@ class WebpackBuildEngine {
       run: forceRun,
       watch: forceWatch,
       inspect: forceInspect,
+      analyze: forceAnalyze,
     });
 
     const config = path.join(
@@ -107,7 +115,7 @@ class WebpackBuildEngine {
     ]
     .join(' ');
 
-    const command = target.is.browser && (target.runOnDevelopment || forceRun) ?
+    const command = !forceAnalyze && target.is.browser && (target.runOnDevelopment || forceRun) ?
       'webpack-dev-server' :
       'webpack';
 
@@ -134,17 +142,26 @@ class WebpackBuildEngine {
       throw new Error('This file can only be run by using the `build` command');
     }
 
-    const { type, run, inspect } = vars;
+    const {
+      type,
+      run,
+      inspect,
+      analyze,
+    } = vars;
     const target = Object.assign({}, this.targets.getTarget(vars.target));
-    if (run === 'true') {
-      target.runOnDevelopment = true;
-      if (inspect === 'true') {
-        target.inspect.enabled = true;
+    if (analyze === 'true') {
+      target.analyze = true;
+    } else {
+      if (run === 'true') {
+        target.runOnDevelopment = true;
+        if (inspect === 'true') {
+          target.inspect.enabled = true;
+        }
       }
-    }
 
-    if (vars.watch === 'true') {
-      target.watch[type] = true;
+      if (vars.watch === 'true') {
+        target.watch[type] = true;
+      }
     }
 
     return this.getConfiguration(target, type);

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -7,6 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const {
   NoEmitOnErrorsPlugin,
   HotModuleReplacementPlugin,
@@ -100,6 +101,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       target,
       output,
       additionalWatch,
+      analyze,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -161,11 +163,17 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
           [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
           []
       ),
+      // If the the bundle should be analyzed, add the plugin for it.
+      ...(
+        analyze ?
+          [new BundleAnalyzerPlugin()] :
+          []
+      ),
     ];
     // Define a list of extra entries that may be need depending on the target HMR configuration.
     const hotEntries = [];
     // If the target needs to run on development...
-    if (target.runOnDevelopment) {
+    if (!analyze && target.runOnDevelopment) {
       const devServerConfig = this._normalizeTargetDevServerSettings(target);
       // Add the dev server information to the configuration.
       config.devServer = {

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -7,6 +7,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { provider } = require('jimple');
 const ConfigurationFile = require('../../abstracts/configurationFile');
 const { ProjextWebpackRuntimeDefinitions } = require('../../plugins');
@@ -73,6 +74,7 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       target,
       output,
       additionalWatch,
+      analyze,
     } = params;
     // Define the basic stuff: entry, output and mode.
     const config = {
@@ -151,6 +153,12 @@ class WebpackBrowserProductionConfiguration extends ConfigurationFile {
       ...(
         additionalWatch.length ?
           [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+          []
+      ),
+      // If the the bundle should be analyzed, add the plugin for it.
+      ...(
+        analyze ?
+          [new BundleAnalyzerPlugin()] :
           []
       ),
     ];

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -5,6 +5,7 @@ const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
 const { provider } = require('jimple');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ConfigurationFile = require('../../abstracts/configurationFile');
 const { ProjextWebpackBundleRunner } = require('../../plugins');
 /**
@@ -69,6 +70,7 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
       output,
       copy,
       additionalWatch,
+      analyze,
     } = params;
     // By default it doesn't watch the source files.
     let watch = false;
@@ -86,9 +88,15 @@ class WebpackNodeDevelopmentConfiguration extends ConfigurationFile {
           [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
           []
       ),
+      // If the the bundle should be analyzed, add the plugin for it.
+      ...(
+        analyze ?
+          [new BundleAnalyzerPlugin()] :
+          []
+      ),
     ];
     // If the target needs to run on development...
-    if (target.runOnDevelopment) {
+    if (!analyze && target.runOnDevelopment) {
       // ...watch the source files.
       watch = true;
       // Push the plugin that executes the target bundle.

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -5,6 +5,7 @@ const {
   NoEmitOnErrorsPlugin,
 } = require('webpack');
 const { provider } = require('jimple');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ConfigurationFile = require('../../abstracts/configurationFile');
 /**
  * Creates the specifics of a Webpack configuration for a Node target production build.
@@ -59,6 +60,7 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
       output,
       copy,
       additionalWatch,
+      analyze,
     } = params;
     const config = {
       entry,
@@ -79,6 +81,12 @@ class WebpackNodeProductionConfiguration extends ConfigurationFile {
         ...(
           additionalWatch.length ?
             [new ExtraWatchWebpackPlugin({ files: additionalWatch })] :
+            []
+        ),
+        // If the the bundle should be analyzed, add the plugin for it.
+        ...(
+          analyze ?
+            [new BundleAnalyzerPlugin()] :
             []
         ),
       ],

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -204,6 +204,8 @@
  * the bundling process.
  * @property {Array} additionalWatch
  * A list of additional paths webpack should watch for in order to restart the bundle.
+ * @property {boolean} analyze
+ * Whether or not the target bundle should be analyzed.
  */
 
 /**

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -222,6 +222,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: [],
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -331,6 +332,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: filesToCopy,
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -440,6 +442,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: filesToCopy,
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -566,6 +569,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: filesToCopy,
       additionalWatch: targetBrowserConfigFiles,
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -683,6 +687,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: [],
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -794,6 +799,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: [],
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
@@ -907,6 +913,7 @@ describe('services/building:configuration', () => {
       targetRules,
       copy: [],
       additionalWatch: [],
+      analyze: false,
     });
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);

--- a/tests/services/building/engine.test.js
+++ b/tests/services/building/engine.test.js
@@ -66,6 +66,7 @@ describe('services/building:engine', () => {
     expect(result).toMatch(/PXTWPK_RUN=false.*?webpack/);
     expect(result).toMatch(/PXTWPK_WATCH=false.*?webpack/);
     expect(result).toMatch(/PXTWPK_INSPECT=false.*?webpack/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=false.*?webpack/);
     expect(result).toMatch(new RegExp(`webpack --config ${expectedConfigPath}`));
     expect(result).toMatch(/webpack --config.*?--progress/);
     expect(result).toMatch(/webpack --config.*?--profile/);
@@ -107,6 +108,7 @@ describe('services/building:engine', () => {
     expect(result).toMatch(/PXTWPK_RUN=false.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_WATCH=false.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_INSPECT=false.*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=false.*?webpack-dev-server/);
     expect(result).toMatch(new RegExp(`webpack-dev-server --config ${expectedConfigPath}`));
     expect(result).toMatch(/webpack-dev-server --config.*?--progress/);
     expect(result).toMatch(/webpack-dev-server --config.*?--profile/);
@@ -146,6 +148,7 @@ describe('services/building:engine', () => {
     expect(result).toMatch(/PXTWPK_RUN=true.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_WATCH=false.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_INSPECT=false.*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=false.*?webpack-dev-server/);
     expect(result).toMatch(/webpack-dev-server --config ([\w_\-/]*?)webpack\.config\.js/);
     expect(result).toMatch(/webpack-dev-server --config.*?--progress/);
     expect(result).toMatch(/webpack-dev-server --config.*?--profile/);
@@ -188,6 +191,7 @@ describe('services/building:engine', () => {
     expect(result).toMatch(/PXTWPK_RUN=false.*?webpack/);
     expect(result).toMatch(/PXTWPK_WATCH=true.*?webpack/);
     expect(result).toMatch(/PXTWPK_INSPECT=false.*?webpack/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=false.*?webpack/);
     expect(result).toMatch(/webpack --config ([\w_\-/]*?)webpack\.config\.js/);
     expect(result).toMatch(/webpack --config.*?--progress/);
     expect(result).toMatch(/webpack --config.*?--profile/);
@@ -230,10 +234,50 @@ describe('services/building:engine', () => {
     expect(result).toMatch(/PXTWPK_RUN=true.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_WATCH=false.*?webpack-dev-server/);
     expect(result).toMatch(/PXTWPK_INSPECT=true.*?webpack-dev-server/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=false.*?webpack-dev-server/);
     expect(result).toMatch(/webpack-dev-server --config ([\w_\-/]*?)webpack\.config\.js/);
     expect(result).toMatch(/webpack-dev-server --config.*?--progress/);
     expect(result).toMatch(/webpack-dev-server --config.*?--profile/);
     expect(result).toMatch(/webpack-dev-server --config.*?--colors/);
+  });
+
+  it('should return the command to build and analyze a target', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const targets = 'targets';
+    const webpackConfiguration = 'webpackConfiguration';
+    const webpackPluginInfo = {
+      name: 'my-projext-plugin-webpack',
+      configuration: 'my-webpack.config.jsx',
+    };
+    const buildType = 'development';
+    const target = {
+      name: 'some-target',
+      is: {
+        browser: true,
+      },
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackBuildEngine(
+      environmentUtils,
+      targets,
+      webpackConfiguration,
+      webpackPluginInfo
+    );
+    result = sut.getBuildCommand(target, buildType, true, false, true, true);
+    // Then
+    expect(result).toMatch(/PXTWPK_TARGET=(?:[\w0-9-_]*?).*?webpack/);
+    expect(result).toMatch(/PXTWPK_TYPE=(?:\w+).*?webpack/);
+    expect(result).toMatch(/PXTWPK_RUN=true.*?webpack/);
+    expect(result).toMatch(/PXTWPK_WATCH=false.*?webpack/);
+    expect(result).toMatch(/PXTWPK_INSPECT=true.*?webpack/);
+    expect(result).toMatch(/PXTWPK_ANALYZE=true.*?webpack/);
+    expect(result).toMatch(/webpack --config ([\w_\-/]*?)webpack\.config\.js/);
+    expect(result).toMatch(/webpack --config.*?--progress/);
+    expect(result).toMatch(/webpack --config.*?--profile/);
+    expect(result).toMatch(/webpack --config.*?--colors/);
   });
 
   it('should return a target webpack configuration from the configurations service', () => {
@@ -273,6 +317,7 @@ describe('services/building:engine', () => {
     const run = false;
     const watch = false;
     const inspect = false;
+    const analyze = false;
     const target = {
       name: targetName,
       watch: {
@@ -285,6 +330,7 @@ describe('services/building:engine', () => {
       PXTWPK_RUN: run.toString(),
       PXTWPK_WATCH: watch.toString(),
       PXTWPK_INSPECT: inspect.toString(),
+      PXTWPK_ANALYZE: analyze.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -330,6 +376,7 @@ describe('services/building:engine', () => {
     const run = true;
     const watch = true;
     const inspect = false;
+    const analyze = false;
     const target = {
       name: targetName,
       watch: {
@@ -345,6 +392,7 @@ describe('services/building:engine', () => {
       PXTWPK_RUN: run.toString(),
       PXTWPK_WATCH: watch.toString(),
       PXTWPK_INSPECT: inspect.toString(),
+      PXTWPK_ANALYZE: analyze.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -399,6 +447,7 @@ describe('services/building:engine', () => {
     const run = true;
     const watch = true;
     const inspect = true;
+    const analyze = false;
     const target = {
       name: targetName,
       watch: {
@@ -412,6 +461,7 @@ describe('services/building:engine', () => {
       PXTWPK_RUN: run.toString(),
       PXTWPK_WATCH: watch.toString(),
       PXTWPK_INSPECT: inspect.toString(),
+      PXTWPK_ANALYZE: analyze.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -462,6 +512,75 @@ describe('services/building:engine', () => {
     });
   });
 
+  it('should return a webpack configuration for bundling and analyzing a target', () => {
+    // Given
+    const targetName = 'some-target';
+    const buildType = 'development';
+    const run = true;
+    const watch = true;
+    const inspect = true;
+    const analyze = true;
+    const target = {
+      name: targetName,
+      watch: {
+        [buildType]: watch,
+      },
+      inspect: {},
+    };
+    const envVars = {
+      PXTWPK_TARGET: targetName,
+      PXTWPK_TYPE: buildType,
+      PXTWPK_RUN: run.toString(),
+      PXTWPK_WATCH: watch.toString(),
+      PXTWPK_INSPECT: inspect.toString(),
+      PXTWPK_ANALYZE: analyze.toString(),
+    };
+    const envVarsNames = Object.keys(envVars);
+    const environmentUtils = {
+      get: jest.fn((varName) => envVars[varName]),
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    const config = 'config';
+    const webpackConfiguration = {
+      getConfig: jest.fn(() => config),
+    };
+    const webpackPluginInfo = {
+      name: 'my-projext-plugin-webpack',
+      configuration: 'my-webpack.config.jsx',
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackBuildEngine(
+      environmentUtils,
+      targets,
+      webpackConfiguration,
+      webpackPluginInfo
+    );
+    result = sut.getWebpackConfig();
+    // Then
+    expect(result).toBe(config);
+    expect(webpackConfiguration.getConfig).toHaveBeenCalledTimes(1);
+    expect(webpackConfiguration.getConfig).toHaveBeenCalledWith(
+      Object.assign(
+        {},
+        target,
+        {
+          analyze: true,
+        }
+      ),
+      buildType
+    );
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetName);
+    expect(environmentUtils.get).toHaveBeenCalledTimes(envVarsNames.length);
+    envVarsNames.forEach((envVar) => {
+      expect(environmentUtils.get).toHaveBeenCalledWith(envVar);
+    });
+  });
+
   it('should throw an error when getting a configuration without the env variables', () => {
     // Given
     const envVarsNames = [
@@ -470,6 +589,7 @@ describe('services/building:engine', () => {
       'PXTWPK_RUN',
       'PXTWPK_WATCH',
       'PXTWPK_INSPECT',
+      'PXTWPK_ANALYZE',
     ];
     const environmentUtils = {
       get: jest.fn(),

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -8,12 +8,14 @@ jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
 jest.mock('optimize-css-assets-webpack-plugin');
 jest.mock('copy-webpack-plugin');
 jest.mock('extra-watch-webpack-plugin');
+jest.mock('webpack-bundle-analyzer');
 jest.unmock('/src/services/configurations/nodeProductionConfiguration');
 
 require('jasmine-expect');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const {
   WebpackNodeProductionConfiguration,
@@ -27,6 +29,7 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     OptimizeCssAssetsPlugin.mockReset();
     CopyWebpackPlugin.mockReset();
     ExtraWatchWebpackPlugin.mockReset();
+    BundleAnalyzerPlugin.mockReset();
   });
 
   it('should be instantiated with all its dependencies', () => {
@@ -207,6 +210,89 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
     expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
     expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      [
+        'webpack-node-production-configuration',
+        'webpack-node-configuration',
+      ],
+      expectedConfig,
+      params
+    );
+  });
+
+  it('should create a configuration with the bundle analyzer', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, loaders) => loaders),
+    };
+    const pathUtils = 'pathUtils';
+    const webpackBaseConfiguration = 'webpackBaseConfiguration';
+    const target = {
+      name: 'targetName',
+      folders: {
+        build: 'build-folder',
+      },
+      excludeModules: [],
+      watch: {
+        production: false,
+      },
+      sourceMap: {
+        production: true,
+      },
+    };
+    const entry = {
+      [target.name]: ['index.js'],
+    };
+    const output = {
+      js: 'statics/js/build.js',
+      jsChunks: 'statics/js/build.[name].js',
+    };
+    const copy = ['file-to-copy'];
+    const additionalWatch = [];
+    const analyze = true;
+    const params = {
+      target,
+      entry,
+      output,
+      copy,
+      additionalWatch,
+      analyze,
+    };
+    const expectedConfig = {
+      entry,
+      output: {
+        path: `./${target.folders.build}`,
+        filename: output.js,
+        chunkFilename: output.jsChunks,
+        publicPath: '/',
+      },
+      mode: 'production',
+      plugins: expect.any(Array),
+      target: 'node',
+      node: {
+        __dirname: false,
+      },
+      watch: target.watch.production,
+      devtool: 'source-map',
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new WebpackNodeProductionConfiguration(
+      events,
+      pathUtils,
+      webpackBaseConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual(expectedConfig);
+    expect(webpackMock.NoEmitOnErrorsPluginMock).toHaveBeenCalledTimes(1);
+    expect(OptimizeCssAssetsPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledTimes(1);
+    expect(CopyWebpackPlugin).toHaveBeenCalledWith(copy);
+    expect(ExtraWatchWebpackPlugin).toHaveBeenCalledTimes(0);
+    expect(BundleAnalyzerPlugin).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,7 +1321,7 @@ acorn-jsx@^5.0.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
   integrity sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
 
-acorn-walk@^6.0.1:
+acorn-walk@^6.0.1, acorn-walk@^6.1.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
@@ -1336,7 +1336,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.2.1:
+acorn@^6.0.1, acorn@^6.0.7, acorn@^6.2.1:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
   integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
@@ -1835,6 +1835,16 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bfj@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
+  integrity sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==
+  dependencies:
+    bluebird "^3.5.5"
+    check-types "^8.0.3"
+    hoopy "^0.1.4"
+    tryer "^1.0.1"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -2261,6 +2271,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-types@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
+  integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
+
 cheerio@0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.20.0.tgz#5c710f2bab95653272842ba01c6ea61b3545ec35"
@@ -2524,7 +2539,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.20.0, commander@^2.8.1, commander@~2.20.0:
+commander@^2.18.0, commander@^2.20.0, commander@^2.8.1, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -3438,6 +3453,11 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -3460,6 +3480,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+ejs@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.2.tgz#3a32c63d1cd16d11266cd4703b14fec4e74ab4f6"
+  integrity sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==
 
 electron-to-chromium@^1.3.191:
   version "1.3.239"
@@ -4011,7 +4036,7 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express@^4.17.1:
+express@^4.16.3, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -4201,6 +4226,11 @@ file-loader@^4.2.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^2.0.0"
+
+filesize@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
+  integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4668,6 +4698,14 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gzip-size@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
+  integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^4.0.1"
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
@@ -4798,6 +4836,11 @@ homedir-polyfill@^1.0.1:
   integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
+
+hoopy@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
+  integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4:
   version "2.8.4"
@@ -9914,6 +9957,11 @@ trim-right@^1.0.1:
   dependencies:
     glob "^7.1.2"
 
+tryer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+  integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
 tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -10297,6 +10345,25 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz#430544c7ba1631baccf673475ca8300cb74a3c47"
+  integrity sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-walk "^6.1.1"
+    bfj "^6.1.1"
+    chalk "^2.4.1"
+    commander "^2.18.0"
+    ejs "^2.6.1"
+    express "^4.16.3"
+    filesize "^3.6.1"
+    gzip-size "^5.0.0"
+    lodash "^4.17.15"
+    mkdirp "^0.5.1"
+    opener "^1.5.1"
+    ws "^6.0.0"
+
 webpack-cli@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.7.tgz#77c8580dd8e92f69d635e0238eaf9d9c15759a91"
@@ -10596,7 +10663,7 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.2.1:
+ws@^6.0.0, ws@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==


### PR DESCRIPTION
### What does this PR do?

This is the implementation of homer0/projext#90. It uses the new `analyze` task (and flag) to enable the [webpack bundle analyzer plugin](https://yarnpkg.com/en/package/webpack-bundle-analyzer)

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

Now:

```bash
projext analyze [target]
```

It should open the bundle analyzer :D.

And, of course...

```bash
yarn test
# or
npm test
```