### PR TITLE
feat(services/configuration/browser): send the build type to the HTML generator

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -123,7 +123,7 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
     config.plugins = [
       // To automatically inject the `script` tag on the target `html` file.
       new HtmlWebpackPlugin(Object.assign({}, target.html, {
-        template: this.targetsHTML.getFilepath(target),
+        template: this.targetsHTML.getFilepath(target, false, 'development'),
         inject: 'body',
       })),
       // To add the `async` attribute to the  `script` tag.

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -200,7 +200,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
   });
 
   it('should create a configuration for a target that injects CSS', () => {
@@ -314,7 +318,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
   });
 
   it('should create a configuration with HMR and source map', () => {
@@ -438,7 +446,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
   });
 
   it('should create a configuration with watch mode', () => {
@@ -555,7 +567,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
   });
 
   it('should create a configuration with the bundle analyzer', () => {
@@ -675,7 +691,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
   });
 
   it('should create a configuration for building and running the dev server', () => {
@@ -821,7 +841,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
@@ -974,7 +998,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
@@ -1126,7 +1154,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
@@ -1286,7 +1318,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
@@ -1444,7 +1480,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedURL, {
       logger: appLogger,
@@ -1603,7 +1643,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedProxiedURL, {
       logger: appLogger,
@@ -1762,7 +1806,11 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       params
     );
     expect(targetsHTML.getFilepath).toHaveBeenCalledTimes(1);
-    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(target);
+    expect(targetsHTML.getFilepath).toHaveBeenCalledWith(
+      target,
+      false,
+      'development'
+    );
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledTimes(1);
     expect(ProjextWebpackOpenDevServer).toHaveBeenCalledWith(expectedProxiedURL, {
       logger: appLogger,


### PR DESCRIPTION
### What does this PR do?

This is a follow up for homer0/projext#91, where the `targetsHTML` service added support for the build type to be sent as parameter.

This PR just sends the build type on the development configuration, as the default value is `production`.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`... then you need to create a plugin, listen for `target-default-html-settings` and check if the third parameter is the build type... just run the tests:

```bash
yarn test
# or
npm test
```
