### PR TITLE
refactor: remove custom implementation of babel/polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "fs-extra": "^8.1.0",
     "extend": "^3.0.2",
 
-    "core-js": "^3.6.1",
-    "regenerator-runtime": "0.13.3",
-
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1",

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,6 @@ const loadPlugin = (app) => {
       'express',
       'jimpex',
     ],
-    babelPolyfill: 'polyfill.js',
   }));
   // Register the main services of the build engine.
   app.register(webpackConfiguration);

--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -16,8 +16,6 @@ class WebpackConfiguration {
    *                                                           configuration for the target.
    * @param {WebpackConfigurations}      webpackConfigurations A dictionary of configurations
    *                                                           for target type and build type.
-   * @param {WebpackPluginInfo}          webpackPluginInfo     To get the path to the Babel
-   *                                                           polyfill.
    */
   constructor(
     buildVersion,
@@ -25,8 +23,7 @@ class WebpackConfiguration {
     targets,
     targetsFileRules,
     targetConfiguration,
-    webpackConfigurations,
-    webpackPluginInfo
+    webpackConfigurations
   ) {
     /**
      * A local reference for the `buildVersion` service.
@@ -58,11 +55,6 @@ class WebpackConfiguration {
      * @type {WebpackConfigurations}
      */
     this.webpackConfigurations = webpackConfigurations;
-    /**
-     * A local reference for the plugin information.
-     * @type {WebpackPluginInfo}
-     */
-    this.webpackPluginInfo = webpackPluginInfo;
   }
   /**
    * This method generates a complete webpack configuration for a target.
@@ -86,12 +78,6 @@ class WebpackConfiguration {
       throw new Error(`There's no configuration for the selected build type: ${buildType}`);
     }
 
-    const entryFile = path.join(target.paths.source, target.entry[buildType]);
-    const entries = [entryFile];
-    if (target.babel.polyfill) {
-      entries.unshift(`${this.webpackPluginInfo.name}/${this.webpackPluginInfo.babelPolyfill}`);
-    }
-
     const copy = [];
     if (target.is.browser || target.bundle) {
       copy.push(...this.targets.getFilesToCopy(target, buildType));
@@ -109,7 +95,7 @@ class WebpackConfiguration {
       target,
       targetRules: this.targetsFileRules.getRulesForTarget(target),
       entry: {
-        [target.name]: entries,
+        [target.name]: [path.join(target.paths.source, target.entry[buildType])],
       },
       definitions,
       output,
@@ -288,8 +274,7 @@ const webpackConfiguration = provider((app) => {
       app.get('targets'),
       app.get('targetsFileRules'),
       app.get('targetConfiguration'),
-      webpackConfigurations,
-      app.get('webpackPluginInfo')
+      webpackConfigurations
     );
   });
 });

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -240,17 +240,8 @@ class WebpackBrowserDevelopmentConfiguration extends ConfigurationFile {
       const [entryName] = Object.keys(entry);
       // Get the list of entries for the target.
       const entries = config.entry[entryName];
-      // Check if the Babel polyfill is present, since it always needs to be first.
-      const polyfillIndex = entries
-      .indexOf(`${this.webpackPluginInfo.name}/${this.webpackPluginInfo.babelPolyfill}`);
-      // If the `babel-polyfill` is present...
-      if (polyfillIndex > -1) {
-        // ...push all the _"hot entries"_ after it.
-        entries.splice(polyfillIndex + 1, 0, ...hotEntries);
-      } else {
-        // ...push all the _"hot entries"_ on top of the existing entries.
-        entries.unshift(...hotEntries);
-      }
+      // and push all the _"hot entries"_ on top of the existing entries.
+      entries.unshift(...hotEntries);
     }
 
     // Reduce the configuration

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -179,8 +179,6 @@
  * @property {Array}  external      The list of subpaths the plugin exposes and that should be
  *                                  handled as external dependencies, in order to avoid bundling
  *                                  them.
- * @property {string} babelPolyfill The name of the file that imports the required modules to
- *                                  act as the old Babel polyfill.
  */
 
 /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -31,7 +31,6 @@ describe('plugin:projextWebpack', () => {
         'express',
         'jimpex',
       ],
-      babelPolyfill: 'polyfill.js',
     });
     expect(app.set).toHaveBeenCalledTimes(1);
     expect(app.set).toHaveBeenCalledWith('webpackPluginInfo', expect.any(Function));

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -25,7 +25,6 @@ describe('services/building:configuration', () => {
     const targetsFileRules = 'targetsFileRules';
     const targetConfiguration = 'targetConfiguration';
     const webpackConfigurations = 'webpackConfigurations';
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     // When
     sut = new WebpackConfiguration(
@@ -34,8 +33,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     // Then
     expect(sut).toBeInstanceOf(WebpackConfiguration);
@@ -45,7 +43,6 @@ describe('services/building:configuration', () => {
     expect(sut.targetsFileRules).toBe(targetsFileRules);
     expect(sut.targetConfiguration).toBe(targetConfiguration);
     expect(sut.webpackConfigurations).toBe(webpackConfigurations);
-    expect(sut.webpackPluginInfo).toBe(webpackPluginInfo);
   });
 
   it('should throw an error when trying to build a target with an invalid type', () => {
@@ -59,7 +56,6 @@ describe('services/building:configuration', () => {
       type: 'random-type',
     };
     const webpackConfigurations = {};
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     // When
     sut = new WebpackConfiguration(
@@ -68,8 +64,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     // Then
     expect(() => sut.getConfig(target))
@@ -90,7 +85,6 @@ describe('services/building:configuration', () => {
     const webpackConfigurations = {
       node: {},
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     // When
     sut = new WebpackConfiguration(
@@ -99,8 +93,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     // Then
     expect(() => sut.getConfig(target, buildType))
@@ -172,7 +165,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     let result = null;
     let definitionsGenerator = null;
@@ -199,8 +191,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     [[{ definitions: definitionsGenerator }]] = targetConfig.getConfig.mock.calls;
@@ -305,7 +296,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     let result = null;
     const expectedParams = {
@@ -330,8 +320,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     // Then
@@ -432,7 +421,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     let result = null;
     const expectedParams = {
@@ -455,8 +443,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     // Then
@@ -560,7 +547,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     let result = null;
     let definitionsGenerator = null;
@@ -587,8 +573,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     [[{ definitions: definitionsGenerator }]] = targetConfig.getConfig.mock.calls;
@@ -626,132 +611,6 @@ describe('services/building:configuration', () => {
     expect(events.reduce).toHaveBeenCalledWith(
       [
         'webpack-configuration-parameters-for-browser',
-        'webpack-configuration-parameters',
-      ],
-      expectedParams
-    );
-  });
-
-  it('should generate the configuration for a target, with the Babel polyfill', () => {
-    // Given
-    const versionVariable = 'process.env.VERSION';
-    const version = 'latest';
-    const buildVersion = {
-      getDefinitionVariable: jest.fn(() => versionVariable),
-      getVersion: jest.fn(() => version),
-    };
-    const pathUtils = {
-      join: jest.fn((rest) => rest),
-    };
-    const config = {
-      output: {
-        path: 'some-output-path',
-      },
-    };
-    const targetConfig = {
-      getConfig: jest.fn(() => config),
-    };
-    const events = {
-      reduce: jest.fn((eventName, configParams) => configParams),
-    };
-    const targets = {
-      loadTargetDotEnvFile: jest.fn(() => ({})),
-      events,
-    };
-    const targetRules = 'target-rule';
-    const targetsFileRules = {
-      getRulesForTarget: jest.fn(() => targetRules),
-    };
-    const targetConfiguration = jest.fn(() => targetConfig);
-    const buildType = 'development';
-    const target = {
-      type: 'node',
-      name: 'target',
-      paths: {
-        source: 'src/target',
-      },
-      entry: {
-        [buildType]: 'index.js',
-      },
-      output: {
-        [buildType]: {
-          js: 'target.js',
-          css: 'css/target/file.2509.css',
-          fonts: 'fonts/target/[name].2509.[ext]',
-          images: 'images/target/[name].2509.[ext]',
-        },
-      },
-      babel: {
-        polyfill: true,
-      },
-      library: false,
-      is: {
-        browser: false,
-        node: true,
-      },
-    };
-    const webpackConfigurations = {
-      [target.type]: {
-        [buildType]: {},
-      },
-    };
-    const webpackPluginInfo = {
-      name: 'plugin',
-      babelPolyfill: 'da-polyfill.js',
-    };
-    let sut = null;
-    let result = null;
-    const expectedParams = {
-      target,
-      buildType,
-      entry: {
-        [target.name]: [
-          `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`,
-          path.join(target.paths.source, target.entry[buildType]),
-        ],
-      },
-      definitions: expect.any(Function),
-      output: Object.assign({}, target.output[buildType], {
-        jsChunks: target.output[buildType].js.replace(/\.js$/, '.[name].js'),
-      }),
-      targetRules,
-      copy: [],
-      additionalWatch: [],
-      analyze: false,
-    };
-    // When
-    sut = new WebpackConfiguration(
-      buildVersion,
-      pathUtils,
-      targets,
-      targetsFileRules,
-      targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
-    );
-    result = sut.getConfig(target, buildType);
-    // Then
-    expect(result).toEqual(config);
-    expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(0);
-    expect(buildVersion.getVersion).toHaveBeenCalledTimes(0);
-    expect(targetConfiguration).toHaveBeenCalledTimes(['global', 'byBuildType'].length);
-    expect(targetConfiguration).toHaveBeenCalledWith(
-      `webpack/${target.name}.config.js`,
-      {}
-    );
-    expect(targetConfiguration).toHaveBeenCalledWith(
-      `webpack/${target.name}.${buildType}.config.js`,
-      targetConfig
-    );
-    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(0);
-    expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
-    expect(targetConfig.getConfig).toHaveBeenCalledWith(expectedParams);
-    expect(pathUtils.join).toHaveBeenCalledTimes(1);
-    expect(pathUtils.join).toHaveBeenCalledWith(config.output.path);
-    expect(events.reduce).toHaveBeenCalledTimes(1);
-    expect(events.reduce).toHaveBeenCalledWith(
-      [
-        'webpack-configuration-parameters-for-node',
         'webpack-configuration-parameters',
       ],
       expectedParams
@@ -820,7 +679,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     const expectedConfig = {
       output: {
         path: 'some-output-path',
@@ -851,8 +709,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     // Then
@@ -947,7 +804,6 @@ describe('services/building:configuration', () => {
         [buildType]: {},
       },
     };
-    const webpackPluginInfo = 'webpackPluginInfo';
     let sut = null;
     let result = null;
     const expectedConfig = {
@@ -978,8 +834,7 @@ describe('services/building:configuration', () => {
       targets,
       targetsFileRules,
       targetConfiguration,
-      webpackConfigurations,
-      webpackPluginInfo
+      webpackConfigurations
     );
     result = sut.getConfig(target, buildType);
     // Then
@@ -1043,6 +898,5 @@ describe('services/building:configuration', () => {
         production: 'webpackBrowserProductionConfiguration',
       },
     });
-    expect(sut.webpackPluginInfo).toBe('webpackPluginInfo');
   });
 });

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -711,7 +711,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -740,13 +739,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -774,7 +769,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,
@@ -866,7 +860,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -896,13 +889,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -931,7 +920,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,
@@ -1025,7 +1013,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -1056,13 +1043,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -1088,10 +1071,7 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
         https: target.devServer.ssl,
       },
       entry: {
-        [target.name]: [
-          babelPolyfillEntry,
-          targetEntry,
-        ],
+        [target.name]: [targetEntry],
       },
       output: {
         path: `./${target.folders.build}`,
@@ -1181,7 +1161,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -1213,13 +1192,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -1249,7 +1224,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,
@@ -1345,7 +1319,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -1378,13 +1351,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -1413,7 +1382,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,
@@ -1507,7 +1475,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -1540,13 +1507,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -1576,7 +1539,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,
@@ -1670,7 +1632,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     const webpackBaseConfiguration = 'webpackBaseConfiguration';
     const webpackPluginInfo = {
       name: 'my-plugin',
-      babelPolyfill: 'polyfill.js',
     };
     const target = {
       name: 'targetName',
@@ -1703,13 +1664,9 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const definitions = 'definitions';
-    const babelPolyfillEntry = `${webpackPluginInfo.name}/${webpackPluginInfo.babelPolyfill}`;
     const targetEntry = '/index.js';
     const entry = {
-      [target.name]: [
-        babelPolyfillEntry,
-        targetEntry,
-      ],
+      [target.name]: [targetEntry],
     };
     const output = {
       js: 'statics/js/build.js',
@@ -1739,7 +1696,6 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       entry: {
         [target.name]: [
-          babelPolyfillEntry,
           `webpack-dev-server/client?${expectedURL}`,
           'webpack/hot/only-dev-server',
           targetEntry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,11 +2838,6 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.1.tgz#39d5e2e346258cc01eb7d44345b1c3c014ca3f05"
-  integrity sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8788,15 +8783,15 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@0.13.3, regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
### What does this PR do?

This is the followup of homer0/projext#97 and almost a revert of #72.

When I added the custom polyfill for Babel I didn't realize that the idea of deprecating it was so the env preset could take care of adding the polyfills when they were necessary.

What I did on #72 was basically add both `core-js` and `regenerator-runtime` to the generated bundles, the entire packages... which resulted on huge builds.

On homer0/projext#97, I properly configured the env preset so it will only include the necessary polyfills, so there's no need to add the `polyfill.js` this plugin was adding; and since the core is now taking care again of the polyfills, there's no need to install `core-js` nor `regenerator-runtime` from here (and since they're not installed, this is a breaking change).

### How should it be tested manually?

First, run `projext analyze` on your target to see how much space is taking `core-js`, then... 

1. Install `projext#next` from Github and this branch.
2. Delete the projext version installed inside this plugin `node_modules` (since this is not installed from a "proper version", `npm`/`yarn`, may install the one required by the plugin inside its directory: `node_modules/projext-plugin-webpack/node_modules/projext`).

Now, run `analyze` again and `core-js` should be "smaller" than before, as now it's only including what it's actually needed.

Also, don't forget to...

```bash
npm test
# or
yarn test
```
